### PR TITLE
Activity Blocking + Crash fixing in HandleTaskHeartBeat

### DIFF
--- a/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
@@ -123,7 +123,7 @@ void UGMCAbility::HandleTaskData(int TaskID, FInstancedStruct TaskData)
 
 void UGMCAbility::HandleTaskHeartbeat(int TaskID)
 {
-	if (RunningTasks.Contains(TaskID))
+	if (RunningTasks.Contains(TaskID) && RunningTasks[TaskID] != nullptr) // Do we ever remove orphans tasks ?
 	{
 		RunningTasks[TaskID]->Heartbeat();
 	}

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -840,6 +840,18 @@ bool UGMC_AbilitySystemComponent::CheckActivationTags(const UGMCAbility* Ability
 		}
 	}
 
+	for (const FGameplayTag Tag : Ability->ActivationBlockedByActiveAbility)
+	{
+		for (const auto& ActiveAbility : ActiveAbilities) {
+			if (IsValid(ActiveAbility.Value)
+				&& ActiveAbility.Value->AbilityTag.MatchesTag(Tag)
+				&& ActiveAbility.Value->AbilityState != EAbilityState::Ended)
+			{
+				return false;
+			}
+		}
+	}
+
 	return true;
 	
 }

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
@@ -189,9 +189,13 @@ public:
 	// Tags that the owner must not have to activate ability. BeginAbility will not be called if the owner has these tags.
 	FGameplayTagContainer ActivationBlockedTags;
 
-	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem", meta=(Categories="Ability"))
 	// Cancel Abilities with these tags when this ability is activated
 	FGameplayTagContainer CancelAbilitiesWithTag;
+
+	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem", meta=(Categories="Ability"))
+	// Ability Tag that the owner must not have to activate ability. BeginAbility will not be called if the owner has these abilities tags.
+	FGameplayTagContainer ActivationBlockedByActiveAbility;
 
 	/** 
 	 * If true, activate on movement tick, if false, activate on ancillary tick. Defaults to true.


### PR DESCRIPTION
- Feature : Activity Blocking by Active ability
- Fixing a crash for undying HandleTaskHeartBeat. 