### PR TITLE
fix(cooldown): store absolute expiry instead of remaining duration

### DIFF
--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -785,20 +785,19 @@ void UGMC_AbilitySystemComponent::QueueTaskData(const FInstancedStruct& InTaskDa
 void UGMC_AbilitySystemComponent::SetCooldownForAbility(const FGameplayTag AbilityTag, float CooldownTime)
 {
 	if (AbilityTag == FGameplayTag::EmptyTag) return;
-	
-	if (ActiveCooldowns.Contains(AbilityTag))
-	{
-		ActiveCooldowns[AbilityTag] = CooldownTime;
-		return;
-	}
-	ActiveCooldowns.Add(AbilityTag, CooldownTime);
+
+	// Store absolute expiry in ActionTimer units. See ActiveCooldowns
+	// declaration for why expiry-time (vs remaining-duration) is required.
+	const double ExpiryActionTime = ActionTimer + static_cast<double>(CooldownTime);
+	ActiveCooldowns.FindOrAdd(AbilityTag) = ExpiryActionTime;
 }
 
 float UGMC_AbilitySystemComponent::GetCooldownForAbility(const FGameplayTag AbilityTag) const
 {
-	if (ActiveCooldowns.Contains(AbilityTag))
+	if (const double* Expiry = ActiveCooldowns.Find(AbilityTag))
 	{
-		return ActiveCooldowns[AbilityTag];
+		const double Remaining = *Expiry - ActionTimer;
+		return Remaining > 0.0 ? static_cast<float>(Remaining) : 0.f;
 	}
 	return 0.f;
 }
@@ -1368,12 +1367,18 @@ void UGMC_AbilitySystemComponent::TickAncillaryActiveAbilities(float DeltaTime){
 	}
 }
 
-void UGMC_AbilitySystemComponent::TickActiveCooldowns(float DeltaTime)
+void UGMC_AbilitySystemComponent::TickActiveCooldowns(float /*DeltaTime*/)
 {
+	// Cooldowns store absolute expiry times (ActionTimer units), not
+	// remaining durations — see ActiveCooldowns declaration. This is
+	// purely a garbage-collection pass for entries whose expiry has
+	// passed. DeltaTime is intentionally ignored: ticking this multiple
+	// times per real frame (which GMC's combined-move re-execution does)
+	// no longer accumulates drift, because expiry is a fixed point in
+	// time, not a counter being decremented.
 	for (auto It = ActiveCooldowns.CreateIterator(); It; ++It)
 	{
-		It.Value() -= DeltaTime;
-		if (It.Value() <= 0)
+		if (It.Value() <= ActionTimer)
 		{
 			It.RemoveCurrent();
 		}

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -977,8 +977,17 @@ private:
 	UPROPERTY()
 	TMap<int, UGMCAbility*> ActiveAbilities;
 	
+	// Active cooldowns keyed by ability tag. Value is the absolute expiry
+	// time in ActionTimer units (i.e. ActionTimer at which the cooldown
+	// ends). Storing as expiry-time rather than remaining-duration is
+	// required to be drift-free under GMC client prediction: combined
+	// client moves cause AncillaryTick to fire multiple times per real
+	// frame on the same move, and a remaining-duration model accumulates
+	// extra decrements (observed 2-2.6x faster than wall clock on a
+	// laggy client). Expiry-time is set once and only compared, so
+	// repeated tick fires are harmless.
 	UPROPERTY()
-	TMap<FGameplayTag, float> ActiveCooldowns;
+	TMap<FGameplayTag, double> ActiveCooldowns;
 
 	int GenerateAbilityID() const {return ActionTimer * 100;}
 	


### PR DESCRIPTION
## Summary

`ActiveCooldowns` stored remaining duration and decremented by `DeltaTime` in `TickActiveCooldowns`. Under GMC client prediction this drifts: combined client moves cause `GenAncillaryTick` to fire multiple times per real frame on the same predicted move, each time with the move's accumulating `MetaData.DeltaTime`. Cooldowns deplete faster than wall clock.

Diagnostic log from a 5s cooldown on a laggy client:

```
[TickActiveCooldowns] DT=0.0083 Before=5.000 After=4.992 WallClock=2.965
[TickActiveCooldowns] DT=0.0083 Before=4.992 After=4.983 WallClock=2.973
[TickActiveCooldowns] DT=0.0167 Before=4.983 After=4.967 WallClock=2.981
[TickActiveCooldowns] DT=0.0250 Before=4.967 After=4.942 WallClock=2.990
[TickActiveCooldowns] DT=0.0333 Before=4.942 After=4.908 WallClock=2.998
[TickActiveCooldowns] DT=0.0083 Before=4.908 After=4.900 WallClock=3.006
```

DTs `0.0083, 0.0167, 0.0250, 0.0333` repeat per cycle — the same combined move's full accumulated DT being re-applied each real frame. The 5s cooldown drained in ~2s of wall clock. Knock-on effect: client `PreBeginAbility::IsOnCooldown()` returns false while the server's cooldown is still active, so the client predicts an activation the server rejects, then hits `ServerConfirmTimeout`.

## Fix

Switch `ActiveCooldowns` storage to absolute expiry time in `ActionTimer` units — the same scheme `EndAtActionTimer` already uses for effects.

- `SetCooldownForAbility(Tag, Duration)` → `ActiveCooldowns[Tag] = ActionTimer + Duration` (once)
- `GetCooldownForAbility(Tag)` → `max(0, Expiry - ActionTimer)`
- `TickActiveCooldowns` → GC pass; removes entries where `Expiry <= ActionTimer`

Repeated tick fires on the same move are idempotent because expiry is a fixed point in time, not a counter being decremented.

Public API unchanged — `SetCooldownForAbility` still takes a float duration, `GetCooldownForAbility` still returns float remaining seconds, `GetCooldownsForInputTag` still returns `TMap<FGameplayTag, float>`. Internal storage type widened to `double` to match `ActionTimer`.

## Test plan

- [x] Builds clean on Win64 Development
- [ ] Standalone: cooldown duration matches `CooldownTime`
- [ ] Client+server with simulated latency: cooldown duration matches `CooldownTime`, `GetCooldownForAbility` returns sane remaining values across the window