### PR TITLE
Fix: drain QueuedTaskData FIFO instead of LIFO

### DIFF
--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -963,7 +963,15 @@ void UGMC_AbilitySystemComponent::PreLocalMoveExecution()
 {
 	if (QueuedTaskData.Num() > 0)
 	{
-		TaskData = QueuedTaskData.Pop();
+		// FIFO. Tasks chained inside a single BP graph push payloads in the
+		// order their tasks were created. The receiving side needs them in
+		// the same order so the dependent task's RunningTasks entry exists
+		// by the time its payload arrives. LIFO (TArray::Pop) reverses the
+		// order, causing the dependent task's payload to arrive before its
+		// own RegisterTask call has run on the remote side → silent dispatch
+		// failure in HandleTaskData (TaskID lookup miss).
+		TaskData = QueuedTaskData[0];
+		QueuedTaskData.RemoveAt(0);
 	}
 	BoundQueueV2.GenPreLocalMoveExecution();
 }


### PR DESCRIPTION
## Summary

`UGMC_AbilitySystemComponent::PreLocalMoveExecution` drains `QueuedTaskData` with `TArray::Pop()`, which removes from the END of the array (LIFO). When a single Blueprint graph chains GMAS tasks back-to-back — for example, one task's `Completed` delegate triggers BP nodes that create a second task whose `Activate` calls `QueueTaskData` — both payloads are pushed onto `QueuedTaskData` in creation order. LIFO drain then reverses that order, so:

1. Move M packets the dependent (second) task's payload into bound `TaskData`.
2. Move M+1 packets the depending (first) task's payload.

On the remote (server / replay) side, the dependent task's payload arrives first. But the dependent task's `RegisterTask` hasn't run yet on that side — it only runs after the depending task's `ProgressTask` fires, which is one move later. So `UGMCAbility::HandleTaskData` does `RunningTasks.Contains(TaskID)` → false → silent drop. The dependent task on the remote side never receives its payload and eventually times out via heartbeat.

This is observable in any setup that builds custom GMAS tasks following the `SetTargetDataVector3` pattern and chains them in a Blueprint graph.

## Fix

Switch the drain to FIFO via `TArray::RemoveAt(0)`. Payloads are delivered to the bound `TaskData` channel in the same order they were queued, so dependent payloads arrive after the BP graph has run the depending task's `Activate` (and therefore `RegisterTask`) on the remote side.

Single-payload-per-task tasks (the existing `SetTargetData*` and `WaitFor*` tasks) are unaffected since there's only ever one item in the queue at drain time.

## Test plan

- [ ] Existing `SetTargetData*` and `WaitFor*` tasks continue to function — payload delivery is order-insensitive for single-payload cases.
- [ ] A Blueprint graph that chains two `QueueTaskData`-using tasks back-to-back (one task's `Completed` triggers BP nodes that activate another task whose `Activate` queues a payload) delivers both payloads in queue order to the remote side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task execution order for chained ability tasks in Blueprint graphs. Tasks now execute sequentially in the proper queue order instead of in reverse sequence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeepWorldsSA/DeepWorlds_GMCAbilitySystem/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->