### PR TITLE
feat(effects): expose EffectData read access for BP override workflows

### DIFF
--- a/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
+++ b/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
@@ -17,6 +17,16 @@ void UGMCAbilityEffect::PostEditChangeProperty(struct FPropertyChangedEvent& Pro
 }
 #endif
 
+FGMCAbilityEffectData UGMCAbilityEffect::GetDefaultEffectData(TSubclassOf<UGMCAbilityEffect> EffectClass)
+{
+	if (!EffectClass)
+	{
+		return FGMCAbilityEffectData{};
+	}
+	const UGMCAbilityEffect* CDO = EffectClass.GetDefaultObject();
+	return CDO ? CDO->EffectData : FGMCAbilityEffectData{};
+}
+
 void UGMCAbilityEffect::InitializeEffect(FGMCAbilityEffectData InitializationData)
 {
 	EffectData = InitializationData;

--- a/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
+++ b/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
@@ -249,7 +249,7 @@ class GMCABILITYSYSTEM_API UGMCAbilityEffect : public UObject
 public:
 	EGMASEffectState CurrentState = EGMASEffectState::Initialized;
 
-	UPROPERTY(EditAnywhere, Category = "GMCAbilitySystem")
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "GMCAbilitySystem")
 	FGMCAbilityEffectData EffectData;
 
 	UPROPERTY(EditDefaultsOnly, Category = "GMCAbilitySystem")
@@ -290,6 +290,25 @@ public:
 	// Return the effect data struct of targeted effect
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category="GMAS|Effects")
 	FGMCAbilityEffectData GetEffectData() const { return EffectData; }
+
+	/**
+	 * Static helper: copy the EffectData struct off the given effect class's CDO.
+	 * Returns an empty struct if EffectClass is null (caller's Apply will fall
+	 * back to CDO via FGMCAbilityEffectData::IsValid()==false).
+	 *
+	 * Intended for the "start from CDO + layer per-cast overrides" pattern:
+	 *
+	 *   Get Default Effect Data: GE_Slow
+	 *     → Set Members in Struct (Duration: 5.0)
+	 *       → Apply Ability Effect (InitializationData = struct)
+	 *
+	 * One-node convenience vs the two-step Get Class Defaults + struct field
+	 * extraction. The Apply call's IsValid() check still passes (CDO content
+	 * present), so the modified struct is used — not the CDO again.
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category="GMAS|Effects",
+	          meta=(DisplayName="Get Default Effect Data"))
+	static FGMCAbilityEffectData GetDefaultEffectData(TSubclassOf<UGMCAbilityEffect> EffectClass);
 
 	// Return the total duration of the effect
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category="GMAS|Effects")


### PR DESCRIPTION
## Summary

Two small changes that together enable the standard "fetch CDO, override fields, apply" pattern for `FGMCAbilityEffectData` from Blueprint without restating the whole struct on every cast.

### Changes

1. **`UGMCAbilityEffect::EffectData` UPROPERTY → `BlueprintReadOnly`.** Currently `EditAnywhere` only. With `BlueprintReadOnly` set, BP authors can use the stock `Get Class Defaults` node on a `UGMCAbilityEffect` subclass and read the `EffectData` field directly — no plugin function needed for the basic case.

2. **New static `UFUNCTION(BlueprintPure)` `GetDefaultEffectData(TSubclassOf<UGMCAbilityEffect>)`.** Returns a copy of the class's CDO `EffectData` in one node. Convenience wrapper over `Get Class Defaults` + struct-field extraction — collapses 2-3 nodes into 1 with a clean struct pin. Returns an empty struct (`!IsValid()`) when given a null class so callers' `ApplyAbilityEffect` calls fall back to CDO defaults naturally.

### Motivation

`ApplyAbilityEffect`'s `InitializationData` parameter is all-or-nothing: if the supplied struct's `IsValid()` returns true (any field set), it REPLACES the CDO entirely. Without these helpers, BP authors who want to tweak a single field (e.g., per-cast Duration override on a Slow effect) must restate every other field on every call site — easy to drop a `GrantedTag`, `Modifier`, or `ApplicationMustNotHaveTags` and silently change behavior.

### Usage pattern

```
Get Default Effect Data: GE_Slow
  → Set Members in Struct (Duration: 5.0)
    → Apply Ability Effect (InitializationData = struct)
```

`Set Members in Struct` (UE built-in) handles top-level field overrides; the modified struct still has CDO content set, so `IsValid()` passes and `ApplyAbilityEffect` uses it instead of the CDO.

### Test plan

- [x] Compiles clean against current dev
- [x] BP-side Get Class Defaults on a UGMCAbilityEffect subclass exposes EffectData for read
- [x] Get Default Effect Data with null class returns empty struct (IsValid==false)

### Files changed

- Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h — BlueprintReadOnly + new GetDefaultEffectData declaration
- Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp — GetDefaultEffectData implementation (10 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ability effect state is now accessible and editable within the Blueprint editor and properties panel.
  * Introduced a helper function for retrieving default ability effect data, enabling easier configuration and setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeepWorldsSA/DeepWorlds_GMCAbilitySystem/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->