### PR TITLE
fix: Server-owned pawns ability activation dropping silently.

### DIFF
--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -2092,15 +2092,9 @@ bool UGMC_AbilitySystemComponent::ProcessOperation(FInstancedStruct OperationDat
 	const UScriptStruct* StructType = PayloadData.GetScriptStruct();
 
 	// Activate Ability — handled in any tick context (AncillaryTick or PredictionTick),
-	// so consume the cache entry here on the auth side.
+	// so consume the cache entry here on the auth side, but only if ability activation succeeds. 
 	if (StructType == FGMASBoundQueueV2AbilityActivationOperation::StaticStruct())
 	{
-		// Server only ever processes operations once so it doesn't need them cached
-		if (HasAuthority())
-		{
-			BoundQueueV2.RemovePayloadByID(OperationID);
-		}
-
 		const FGMASBoundQueueV2AbilityActivationOperation Data = PayloadData.Get<FGMASBoundQueueV2AbilityActivationOperation>();
 		if (!BoundQueueV2.bInBatchDispatch)
 		{
@@ -2120,7 +2114,14 @@ bool UGMC_AbilitySystemComponent::ProcessOperation(FInstancedStruct OperationDat
 
 		// Thread the operation ID through so AbilityIDs are operation-derived and identical
 		// on client and server (Data.OperationID was stamped once by the queueing side).
-		return TryActivateAbilitiesByInputTag(Data.InputTag, Data.InputAction, bFromMovementTick, bForce, Data.OperationID);
+		bool bSuccess = TryActivateAbilitiesByInputTag(Data.InputTag, Data.InputAction, bFromMovementTick, bForce, Data.OperationID);
+
+		if (HasAuthority() && bSuccess)
+		{
+			BoundQueueV2.RemovePayloadByID(OperationID);
+		}
+
+		return bSuccess;
 	}
 
 	// Everything below happens only during the Prediction tick (or via the forced

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -2111,17 +2111,22 @@ bool UGMC_AbilitySystemComponent::ProcessOperation(FInstancedStruct OperationDat
 				OperationID, *Data.InputTag.ToString(),
 				HasAuthority() ? 1 : 0, bFromMovementTick ? 1 : 0, bForce ? 1 : 0);
 		}
-
+		
 		// Thread the operation ID through so AbilityIDs are operation-derived and identical
 		// on client and server (Data.OperationID was stamped once by the queueing side).
-		bool bSuccess = TryActivateAbilitiesByInputTag(Data.InputTag, Data.InputAction, bFromMovementTick, bForce, Data.OperationID);
+		const bool bActivated = TryActivateAbilitiesByInputTag(Data.InputTag, Data.InputAction, bFromMovementTick, bForce, Data.OperationID);
 
-		if (HasAuthority() && bSuccess)
+		// The ability can fail if it is running on the irrelevant tick, hence we preserve the payload when necessary.
+		if (HasAuthority())
 		{
-			BoundQueueV2.RemovePayloadByID(OperationID);
+			const bool bPreserveForAncillaryTick = !bActivated && bFromMovementTick;
+			if (!bPreserveForAncillaryTick)
+			{
+				BoundQueueV2.RemovePayloadByID(OperationID);
+			}
 		}
 
-		return bSuccess;
+		return bActivated;
 	}
 
 	// Everything below happens only during the Prediction tick (or via the forced


### PR DESCRIPTION
## Summary
When a server-owned pawn attempts to activate an ability that has `bRunOnMovementTick == false`, it is being silently dropped. The queue payload is currently being consumed regardless of whether `TryActivateAbilitiesByInputTag()` succeeds. 

## Fix
Updated the payload to only be removed if `TryActivateAbilitiesByInputTag()` returns true. 

Tested this fix without the experimental fix 8c91d5e0eafaaf47da933f91d398834841d7172d by @Aherys:
- Linked fix is **_still required_** for server-owned ability activation to fire correctly.
- Without the fix, the ability would fail, then succeed exactly one second after failure.

---

```
bPreserveForAncillaryTick = !bActivated && bFromMovementTick
```
From my testing, we can't remove the payload just from bActivated as this would cause clients ability activation to throw Operation ID mismatch errors. From my understanding, this is due to how client fire its ability differently from server. 

---

Note that the payload is **_always being processed twice_**. 
```
[2026.05.21-21.41.21:610][922]LogGMCAbilitySystem: Warning: Ability Activation: false
[2026.05.21-21.41.21:610][922]LogGMCAbilitySystem: Warning: Ability Activation: true
```

The first instance always fails as the instance is running on MovementTick and being dropped by this guard:
```
	if (!bForce && bFirstAbilityActivatesDuringMovementTick != bFromMovementTick)
	{
		// If the first ability doesn't match the bFromMovementTick state, we can't activate any abilities
		return false;
	}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Test Scenarios
✅ Server-Owned Pawn Ability Activation - bRunOnMovementTick == true
✅ Server-Owned Pawn Ability Activation - bRunOnMovementTick == false
✅ Client-Owned Pawn Ability Activation - bRunOnMovementTick == true
✅ Client-Owned Pawn Ability Activation - bRunOnMovementTick == false

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side ability activation handling to ensure proper operation payload management, enhancing the reliability of ability activations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeepWorldsSA/DeepWorlds_GMCAbilitySystem/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->