### PR TITLE
Add Blueprint-accessible GetAbilityCostValues to UGMCAbility

### DIFF
--- a/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
@@ -144,6 +144,19 @@ void UGMCAbility::RemoveAbilityCost() {
 	}
 }
 
+TMap<FGameplayTag, float> UGMCAbility::GetAbilityCostValues() const
+{
+	TMap<FGameplayTag, float> CostMap;
+	if (!AbilityCost) return CostMap;
+
+	const UGMCAbilityEffect* EffectCDO = AbilityCost->GetDefaultObject<UGMCAbilityEffect>();
+    
+	for (const FGMCAttributeModifier& Modifier : EffectCDO->EffectData.Modifiers)
+	{
+		CostMap.Add(Modifier.AttributeTag, Modifier.GetValue()); 
+	}
+	return CostMap;
+}
 
 void UGMCAbility::ModifyBlockOtherAbility(FGameplayTagContainer TagToAdd, FGameplayTagContainer TagToRemove) {
 	for (auto Tag : TagToAdd) {

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
@@ -164,6 +164,11 @@ public:
 	// Remove the ability cost effect (if applicable)
 	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")
 	virtual void RemoveAbilityCost();
+	
+	// Retrieves the attribute costs of this ability from its AbilityCost effect class.
+	// @return A map of GameplayTags (Attributes) to their respective modifier values.
+	UFUNCTION(BlueprintPure, Category = "GMCAbilitySystem")
+	TMap<FGameplayTag, float> GetAbilityCostValues() const;
 
 	// Live modifying the BlockOtherAbility tags
 	UFUNCTION(BlueprintCallable, Category = "GMCAbilitySystem")


### PR DESCRIPTION
Added a helper function to easily retrieve and map the attribute costs associated with an ability.

Functionality: Iterates through the AbilityCost effect CDO to extract the modifiers.

Returns: A TMap<FGameplayTag, float> that maps attribute tags directly to their exact modifier values.

Use Case: Simplifies querying and accessing ability costs for UI display and Blueprint logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `GetAbilityCostValues()` method to retrieve cost values for abilities. Available in both Blueprints and code, the method returns a map of attribute tags with their associated cost values configured for each ability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->