### PR TITLE
Held-ability cut diagnostics + stale-modifier crash guard + PostEditChangeProperty visibility fix

### DIFF
--- a/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
@@ -3,6 +3,60 @@
 #include "GMCPawn.h"
 #include "Ability/Tasks/GMCAbilityTaskBase.h"
 #include "Components/GMCAbilityComponent.h"
+#include "HAL/PlatformTime.h"
+
+namespace GMCAbilityCutDiag
+{
+	static const TCHAR* TaskStateToString(const EGameplayTaskState State)
+	{
+		switch (State)
+		{
+		case EGameplayTaskState::Uninitialized:      return TEXT("Uninitialized");
+		case EGameplayTaskState::AwaitingActivation: return TEXT("AwaitingActivation");
+		case EGameplayTaskState::Paused:             return TEXT("Paused");
+		case EGameplayTaskState::Active:             return TEXT("Active");
+		case EGameplayTaskState::Finished:           return TEXT("Finished");
+		default:                                     return TEXT("Unknown");
+		}
+	}
+}
+
+FString UGMCAbility::GetAbilityCutDiagnostics() const
+{
+	const double Now = FPlatformTime::Seconds();
+	const bool bAuthority = OwnerAbilityComponent && OwnerAbilityComponent->HasAuthority();
+	const bool bReplaying = OwnerAbilityComponent && OwnerAbilityComponent->IsReplayingForGMASLogic();
+	const float Timer = OwnerAbilityComponent ? OwnerAbilityComponent->ActionTimer : -1.f;
+
+	FString Out = FString::Printf(
+		TEXT("Ability=%s Tag=%s AbilityID=%d State=%s ServerConfirmed=%d MovementTick=%d Authority=%d Replaying=%d ActionTimer=%.3f ClientStartTime=%.3f Age=%.3f Tasks=%d"),
+		*GetName(), *AbilityTag.ToString(), AbilityID, *EnumToString(AbilityState),
+		bServerConfirmed ? 1 : 0, bActivateOnMovementTick ? 1 : 0, bAuthority ? 1 : 0, bReplaying ? 1 : 0,
+		Timer, ClientStartTime, Timer - ClientStartTime, RunningTasks.Num());
+
+	for (const TPair<int, UGMCAbilityTaskBase*>& TaskPair : RunningTasks)
+	{
+		const UGMCAbilityTaskBase* Task = TaskPair.Value;
+		if (!Task)
+		{
+			Out += FString::Printf(TEXT("\n  - TaskID=%d <null>"), TaskPair.Key);
+			continue;
+		}
+
+		// Heartbeat stamps are wall-clock (FPlatformTime) — ages can be negative right after
+		// Activate because the received-stamp is seeded one grace interval into the future.
+		Out += FString::Printf(
+			TEXT("\n  - TaskID=%d Class=%s State=%s Completed=%d HeartbeatsRcv=%d LastRcvAge=%.2fs LastSentAge=%.2fs"),
+			TaskPair.Key, *Task->GetClass()->GetName(),
+			GMCAbilityCutDiag::TaskStateToString(Task->GetState()),
+			Task->IsTaskCompleted() ? 1 : 0,
+			Task->GetHeartbeatReceivedCount(),
+			Now - Task->GetLastHeartbeatReceivedTime(),
+			Task->GetClientLastHeartbeatSentTime() > 0.0 ? Now - Task->GetClientLastHeartbeatSentTime() : -1.0);
+	}
+
+	return Out;
+}
 
 UWorld* UGMCAbility::GetWorld() const
 {
@@ -45,8 +99,13 @@ void UGMCAbility::Tick(float DeltaTime)
 	{
 		if (!bServerConfirmed && ClientStartTime + ServerConfirmTimeout < OwnerAbilityComponent->ActionTimer)
 		{
-			
-			UE_LOGFMT(LogGMCAbilitySystem, Error, "[Client] Ability Not Confirmed By Server: {0}, Removing... (Was Replaying : {1})", AbilityID, GetOwnerMovementComponent()->CL_IsReplaying() ? "True" : "False");
+			// [AbilityCut] probe: the server never confirmed this AbilityID within the timeout.
+			// Either the server rejected/never ran the activation, or client/server generated
+			// diverging AbilityIDs and the confirm RPC targeted an instance we don't have.
+			// Full task dump so the log shows what the prediction was doing when it died.
+			UE_LOG(LogGMCAbilitySystem, Error,
+				TEXT("[AbilityCut] Client removing unconfirmed ability after %.2fs (no RPCConfirmAbilityActivation received). %s"),
+				ServerConfirmTimeout, *GetAbilityCutDiagnostics());
 			EndAbility();
 			return;
 		}
@@ -167,7 +226,38 @@ void UGMCAbility::HandleTaskData(int TaskID, FInstancedStruct TaskData)
 	{
 		if (TaskDataFromInstance.TaskType == EGMCAbilityTaskDataType::Progress)
 		{
-			RunningTasks[TaskID]->ProgressTask(TaskData);
+			// Idempotency guard for ALL task types: Progress payloads ride a GMC-bound
+			// ClientAuth_Input, so a client replay re-delivers the historical payload of every
+			// replayed move. No ProgressTask implementation (SetTargetData*, WaitForInputKey*)
+			// guards against re-entry on a finished task — without this gate the re-delivery
+			// re-broadcasts Completed and re-runs the BP continuation (double heal/commit,
+			// client-only task creation -> TaskID divergence -> heartbeat watchdog kill).
+			UGMCAbilityTaskBase* Task = RunningTasks[TaskID];
+			if (Task->IsTaskCompleted() || Task->GetState() == EGameplayTaskState::Finished)
+			{
+				UE_LOG(LogGMCAbilitySystem, Verbose,
+					TEXT("[TaskDiag] Progress payload ignored for already-finished task (TaskID=%d, Replaying=%d)."),
+					TaskID, OwnerAbilityComponent && OwnerAbilityComponent->IsReplayingForGMASLogic() ? 1 : 0);
+				return;
+			}
+			Task->ProgressTask(TaskData);
+		}
+	}
+	else
+	{
+		// [TaskDiag] probe: a Progress payload arrived for a TaskID this side never registered
+		// (or already dropped). This is the silent dispatch failure that leaves the other
+		// side's task waiting forever — TaskIDs are independent per-side counters, so any
+		// asymmetric task creation (e.g. a BP branch firing on one side only, or a replay
+		// double-executing a graph) shifts every subsequent ID.
+		UE_LOG(LogGMCAbilitySystem, Warning,
+			TEXT("[TaskDiag] Progress payload dropped: TaskID=%d not in RunningTasks. %s"),
+			TaskID, *GetAbilityCutDiagnostics());
+		if (OwnerAbilityComponent && OwnerAbilityComponent->HasAuthority())
+		{
+			UE_LOG(LogTemp, Warning,
+				TEXT("[TaskDiag] Progress payload dropped: TaskID=%d not in RunningTasks. %s"),
+				TaskID, *GetAbilityCutDiagnostics());
 		}
 	}
 }
@@ -177,6 +267,22 @@ void UGMCAbility::HandleTaskHeartbeat(int TaskID)
 	if (RunningTasks.Contains(TaskID) && RunningTasks[TaskID] != nullptr) // Do we ever remove orphans tasks ?
 	{
 		RunningTasks[TaskID]->Heartbeat();
+	}
+	else
+	{
+		// [TaskDiag] probe: the client is heartbeating a TaskID the server doesn't have.
+		// The client-side ability is alive (it sent this) but its task layout diverged from
+		// ours — the matching server task is starving and the watchdog will cancel the
+		// ability within HeartbeatMaxInterval. Throttled naturally by the 1/s send rate.
+		UE_LOG(LogGMCAbilitySystem, Warning,
+			TEXT("[TaskDiag] Heartbeat for unknown TaskID=%d. %s"),
+			TaskID, *GetAbilityCutDiagnostics());
+		if (OwnerAbilityComponent && OwnerAbilityComponent->HasAuthority())
+		{
+			UE_LOG(LogTemp, Warning,
+				TEXT("[TaskDiag] Heartbeat for unknown TaskID=%d. %s"),
+				TaskID, *GetAbilityCutDiagnostics());
+		}
 	}
 }
 
@@ -265,7 +371,36 @@ void UGMCAbility::OnGameplayTaskDeactivated(UGameplayTask& Task)
 
 
 void UGMCAbility::FinishEndAbility() {
-	
+
+	// [AbilityCut] probe: an ability ending while it still has unfinished tasks is the
+	// fingerprint of an abnormal cut (watchdog kill, confirm timeout, cancel-by-other,
+	// gameplay guard, forced server end). Normal completions end with every task already
+	// completed/finished. Logged on BOTH sides: the side that dies FIRST is the root cause —
+	// the other side follows seconds later (client stops heartbeating -> server watchdog,
+	// or server RPCClientEndAbility -> client). Compare timestamps across the two logs.
+	int32 UnfinishedTasks = 0;
+	for (const TPair<int, UGMCAbilityTaskBase*>& Task : RunningTasks)
+	{
+		if (Task.Value && !Task.Value->IsTaskCompleted() && Task.Value->GetState() != EGameplayTaskState::Finished)
+		{
+			UnfinishedTasks++;
+		}
+	}
+	if (UnfinishedTasks > 0)
+	{
+		UE_LOG(LogGMCAbilitySystem, Warning,
+			TEXT("[AbilityCut] Ability ending with %d unfinished task(s). %s"),
+			UnfinishedTasks, *GetAbilityCutDiagnostics());
+		// Mirror onto LogTemp: the dedicated-server log export only ships a fixed category
+		// allowlist (LogTemp included, LogGMCAbilitySystem not).
+		if (OwnerAbilityComponent && OwnerAbilityComponent->HasAuthority())
+		{
+			UE_LOG(LogTemp, Warning,
+				TEXT("[AbilityCut] Ability ending with %d unfinished task(s). %s"),
+				UnfinishedTasks, *GetAbilityCutDiagnostics());
+		}
+	}
+
 	for (const TPair<int, UGMCAbilityTaskBase* >& Task : RunningTasks)
 	{
 		if (Task.Value == nullptr) continue;

--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/GMCAbilityTaskBase.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/GMCAbilityTaskBase.cpp
@@ -13,6 +13,18 @@ void UGMCAbilityTaskBase::Activate()
 	// Seed with a real-time stamp plus one full interval of grace, so a task that activates
 	// just before its first heartbeat round-trip completes is not cancelled prematurely.
 	LastHeartbeatReceivedTime = FPlatformTime::Seconds() + HeartbeatMaxInterval;
+
+	// [TaskDiag] probe: a task registered DURING a client replay is created on the client
+	// ONLY (the server never replays), so the per-ability TaskIDCounter diverges from here
+	// on — every later task on this ability gets mismatched IDs, Progress payloads dispatch
+	// to the wrong/missing task and heartbeats starve the server twin until its watchdog
+	// cancels the ability. This is the smoking gun for replay-induced cuts.
+	if (AbilitySystemComponent.IsValid() && AbilitySystemComponent->IsReplayingForGMASLogic())
+	{
+		UE_LOG(LogGMCAbilitySystem, Error,
+			TEXT("[TaskDiag] Task %s registered DURING replay (TaskID=%d) — client/server TaskID divergence from this point. %s"),
+			*GetClass()->GetName(), TaskID, Ability ? *Ability->GetAbilityCutDiagnostics() : TEXT("<no ability>"));
+	}
 }
 
 void UGMCAbilityTaskBase::EndTaskGMAS()
@@ -37,6 +49,10 @@ void UGMCAbilityTaskBase::Tick(float DeltaTime)
 }
 
 void UGMCAbilityTaskBase::AncillaryTick(float DeltaTime){
+	// AbilitySystemComponent is a TWeakObjectPtr: during pawn teardown / possession change the
+	// component can die while this task is still registered, and a stale dereference crashes.
+	if (!AbilitySystemComponent.IsValid() || !AbilitySystemComponent->GMCMovementComponent) return;
+
 	// Locally controlled server pawns don't need to send heartbeats
 	if (AbilitySystemComponent->GMCMovementComponent->IsLocallyControlledServerPawn()) return;
 
@@ -63,9 +79,15 @@ void UGMCAbilityTaskBase::AncillaryTick(float DeltaTime){
 		// Mirror onto LogTemp: the dedicated-server GS log export only ships a fixed category
 		// allowlist (LogTemp included, LogGMCReplication not), so a LogGMCReplication-only line
 		// is invisible in server log dumps. This watchdog is what silently cancels heal-consume.
-		UE_LOG(LogTemp, Error, TEXT("[TaskHeartbeat] Timeout: cancelling ability '%s' (tag '%s') - task %s (TaskID %d), %.2fs since last heartbeat (max %.2f), %d heartbeats received"),
+		// Full task dump appended: the timed-out task is merely the FIRST one to starve —
+		// when the client stops heartbeating, every task starves at once, so what matters is
+		// the whole-ability picture (which tasks had completed, which never progressed,
+		// heartbeat counts per task) plus whether the timed-out task was even still pending.
+		UE_LOG(LogTemp, Error, TEXT("[TaskHeartbeat] Timeout: cancelling ability '%s' (tag '%s') - task %s (TaskID %d, Completed=%d), %.2fs since last heartbeat (max %.2f), %d heartbeats received. %s"),
 		  *Ability->GetName(), *Ability->AbilityTag.ToString(), *GetClass()->GetName(), TaskID,
-		  TimeSinceLastHeartbeat, HeartbeatMaxInterval, HeartbeatReceivedCount);
+		  bTaskCompleted ? 1 : 0,
+		  TimeSinceLastHeartbeat, HeartbeatMaxInterval, HeartbeatReceivedCount,
+		  *Ability->GetAbilityCutDiagnostics());
 		AbilitySystemComponent->OnTaskTimeout.Broadcast(Ability->AbilityTag);
 		Ability->EndAbility();
 		EndTask();

--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyPress.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyPress.cpp
@@ -46,8 +46,10 @@ void UGMCAbilityTask_WaitForInputKeyPress::Activate()
 		if (bShouldCheckForPressDuringActivation && IsClientOrRemoteListenServerPawn())
 		{
 			FInputActionValue ActionValue = FInputActionValue();
+			// PC can be null during possession transitions (and GetLocalPlayer on a remote PC) —
+			// guard the chain instead of dereferencing blindly.
 			APlayerController* PC = AbilitySystemComponent->GetOwner()->GetInstigatorController<APlayerController>();
-			if (UEnhancedInputLocalPlayerSubsystem* InputSubSystem = ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(PC->GetLocalPlayer())) {
+			if (UEnhancedInputLocalPlayerSubsystem* InputSubSystem = PC ? ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(PC->GetLocalPlayer()) : nullptr) {
 				ActionValue = InputSubSystem->GetPlayerInput() ? InputSubSystem->GetPlayerInput()->GetActionValue(Ability->AbilityInputAction) : FInputActionValue();
 			}
 
@@ -107,6 +109,11 @@ UEnhancedInputComponent* UGMCAbilityTask_WaitForInputKeyPress::GetEnhancedInputC
 
 void UGMCAbilityTask_WaitForInputKeyPress::OnTaskCompleted()
 {
+	// Completion latch BEFORE the broadcast: a re-entrant Completed handler (or a replayed
+	// Progress payload) must see the task as already done, not run the completion twice.
+	if (bTaskCompleted) return;
+	bTaskCompleted = true;
+
 	EndTask();
 	Duration = AbilitySystemComponent->ActionTimer - StartTime;
 	if (!bTimedOut)
@@ -117,7 +124,6 @@ void UGMCAbilityTask_WaitForInputKeyPress::OnTaskCompleted()
 	{
 		TimedOut.Broadcast(Duration);
 	}
-	bTaskCompleted = true;
 }
 
 void UGMCAbilityTask_WaitForInputKeyPress::OnDestroy(bool bInOwnerFinished)

--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyPressParameterized.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyPressParameterized.cpp
@@ -42,8 +42,10 @@ void UGMCAbilityTask_WaitForInputKeyPressParameterized::Activate()
 			if (bShouldCheckForPressDuringActivation)
 			{
 				FInputActionValue ActionValue = FInputActionValue();
+				// PC can be null during possession transitions (and GetLocalPlayer on a remote PC) —
+				// guard the chain instead of dereferencing blindly.
 				APlayerController* PC = AbilitySystemComponent->GetOwner()->GetInstigatorController<APlayerController>();
-				if (UEnhancedInputLocalPlayerSubsystem* InputSubSystem = ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(PC->GetLocalPlayer())) {
+				if (UEnhancedInputLocalPlayerSubsystem* InputSubSystem = PC ? ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(PC->GetLocalPlayer()) : nullptr) {
 					ActionValue = InputSubSystem->GetPlayerInput() ? InputSubSystem->GetPlayerInput()->GetActionValue(Ability->AbilityInputAction) : FInputActionValue();
 				}
 				if (ActionValue.GetMagnitude() == 1)
@@ -104,6 +106,11 @@ UEnhancedInputComponent* UGMCAbilityTask_WaitForInputKeyPressParameterized::GetE
 
 void UGMCAbilityTask_WaitForInputKeyPressParameterized::OnTaskCompleted()
 {
+	// Completion latch BEFORE the broadcast: a re-entrant Completed handler (or a replayed
+	// Progress payload) must see the task as already done, not run the completion twice.
+	if (bTaskCompleted) return;
+	bTaskCompleted = true;
+
 	EndTask();
 	Duration = AbilitySystemComponent->ActionTimer - StartTime;
 	if (!bTimedOut)
@@ -114,7 +121,6 @@ void UGMCAbilityTask_WaitForInputKeyPressParameterized::OnTaskCompleted()
 	{
 		TimedOut.Broadcast(Duration);
 	}
-	bTaskCompleted = true;
 }
 
 void UGMCAbilityTask_WaitForInputKeyPressParameterized::OnDestroy(bool bInOwnerFinished)

--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyRelease.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyRelease.cpp
@@ -48,8 +48,10 @@ void UGMCAbilityTask_WaitForInputKeyRelease::Activate()
 			&& !AbilitySystemComponent->IsReplayingForGMASLogic())
 		{
 			FInputActionValue ActionValue = FInputActionValue();
+			// PC can be null during possession transitions (and GetLocalPlayer on a remote PC) —
+			// guard the chain instead of dereferencing blindly.
 			APlayerController* PC = AbilitySystemComponent->GetOwner()->GetInstigatorController<APlayerController>();
-			if (UEnhancedInputLocalPlayerSubsystem* InputSubSystem = ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(PC->GetLocalPlayer())) {
+			if (UEnhancedInputLocalPlayerSubsystem* InputSubSystem = PC ? ULocalPlayer::GetSubsystem<UEnhancedInputLocalPlayerSubsystem>(PC->GetLocalPlayer()) : nullptr) {
 				ActionValue = InputSubSystem->GetPlayerInput() ? InputSubSystem->GetPlayerInput()->GetActionValue(Ability->AbilityInputAction) : FInputActionValue();
 			}
 
@@ -106,6 +108,11 @@ UEnhancedInputComponent* UGMCAbilityTask_WaitForInputKeyRelease::GetEnhancedInpu
 
 void UGMCAbilityTask_WaitForInputKeyRelease::OnTaskCompleted()
 {
+	// Completion latch BEFORE the broadcast: a re-entrant Completed handler (or a replayed
+	// Progress payload) must see the task as already done, not run the completion twice.
+	if (bTaskCompleted) return;
+	bTaskCompleted = true;
+
 	EndTask();
 	Duration = AbilitySystemComponent->ActionTimer - StartTime;
 	if (!bTimedOut)
@@ -116,7 +123,6 @@ void UGMCAbilityTask_WaitForInputKeyRelease::OnTaskCompleted()
 	{
 		TimedOut.Broadcast(Duration);
 	}
-	bTaskCompleted = true;
 }
 
 void UGMCAbilityTask_WaitForInputKeyRelease::OnDestroy(bool bInOwnerFinished)

--- a/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeModifier.cpp
+++ b/Source/GMCAbilitySystem/Private/Attributes/GMCAttributeModifier.cpp
@@ -40,8 +40,25 @@ float FGMCAttributeModifier::GetValue() const
 
 float FGMCAttributeModifier::CalculateModifierValue(const FAttribute& Attribute) const
 {
-		float TargetValue = GetValue();
-	
+	float TargetValue = GetValue();
+
+	// Resolve the source ASC ONCE with the weak-ptr validated. SourceAbilityEffect is a
+	// TWeakObjectPtr: a modifier kept in the attribute's temporal history can outlive its
+	// effect (GC after EndEffect), and every attribute-driven op below used to dereference
+	// the stale pointer raw — GetValue() above guards, these branches did not.
+	UGMC_AbilitySystemComponent* SourceASC =
+		SourceAbilityEffect.IsValid() ? SourceAbilityEffect->GetOwnerAbilityComponent() : nullptr;
+	const auto GetSourceAttributeValue = [SourceASC](const FGameplayTag& InAttributeTag) -> float
+	{
+		if (SourceASC)
+		{
+			return SourceASC->GetAttributeValueByTag(InAttributeTag);
+		}
+		UE_LOG(LogGMCAbilitySystem, Error,
+			TEXT("FGMCAttributeModifier::CalculateModifierValue: SourceAbilityEffect/ASC stale, attribute-driven modifier falls back to 0."));
+		return 0.f;
+	};
+
 	// First set Percentage values to a fraction
 	switch (Op)
 	{
@@ -55,7 +72,7 @@ float FGMCAttributeModifier::CalculateModifierValue(const FAttribute& Attribute)
 			TargetValue /= 100.f;
 		break;
 	}
-	
+
 	switch (Op)
 	{
 		case EModifierType::Add:
@@ -63,15 +80,15 @@ float FGMCAttributeModifier::CalculateModifierValue(const FAttribute& Attribute)
 		case EModifierType::AddPercentageInitialValue:
 			return Attribute.InitialValue * TargetValue * DeltaTime;
 		case EModifierType::AddPercentageAttribute:
-			return SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(ValueAsAttribute) * TargetValue * DeltaTime;
+			return GetSourceAttributeValue(ValueAsAttribute) * TargetValue * DeltaTime;
 		case EModifierType::AddPercentageMaxClamp:
 			{
-				const float MaxValue = Attribute.Clamp.MaxAttributeTag.IsValid() ? SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(Attribute.Clamp.MaxAttributeTag) : Attribute.Clamp.Max;
+				const float MaxValue = Attribute.Clamp.MaxAttributeTag.IsValid() && SourceASC ? GetSourceAttributeValue(Attribute.Clamp.MaxAttributeTag) : Attribute.Clamp.Max;
 				return MaxValue * TargetValue * DeltaTime;
 			}
 		case EModifierType::AddPercentageMinClamp:
 			{
-				const float MinValue = Attribute.Clamp.MinAttributeTag.IsValid() ? SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(Attribute.Clamp.MinAttributeTag) : Attribute.Clamp.Min;
+				const float MinValue = Attribute.Clamp.MinAttributeTag.IsValid() && SourceASC ? GetSourceAttributeValue(Attribute.Clamp.MinAttributeTag) : Attribute.Clamp.Min;
 				return MinValue * TargetValue * DeltaTime;
 			}
 		case EModifierType::AddPercentageAttributeSum:
@@ -79,20 +96,20 @@ float FGMCAttributeModifier::CalculateModifierValue(const FAttribute& Attribute)
 				float Sum = 0.f;
 				for (auto& AttTag : Attributes)
 				{
-					Sum += SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(AttTag);
+					Sum += GetSourceAttributeValue(AttTag);
 				}
 				return TargetValue * Sum * DeltaTime;
 			}
 		case EModifierType::AddScaledBetween:
 			{
-				const float XBound = XAsAttribute ? SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(XAttribute) : X;
-				const float YBound = YAsAttribute ? SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(YAttribute) : Y;
+				const float XBound = XAsAttribute ? GetSourceAttributeValue(XAttribute) : X;
+				const float YBound = YAsAttribute ? GetSourceAttributeValue(YAttribute) : Y;
 				return FMath::Clamp(FMath::Lerp(XBound, YBound, TargetValue), X, Y) * DeltaTime;
 			}
 		case EModifierType::AddClampedBetween:
 			{
-				const float XBound = XAsAttribute ? SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(XAttribute) : X;
-				const float YBound = YAsAttribute ? SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeValueByTag(YAttribute) : Y;
+				const float XBound = XAsAttribute ? GetSourceAttributeValue(XAttribute) : X;
+				const float YBound = YAsAttribute ? GetSourceAttributeValue(YAttribute) : Y;
 				return FMath::Clamp(TargetValue, XBound, YBound) * DeltaTime;
 			}
 		case EModifierType::AddPercentageMissing:
@@ -102,7 +119,7 @@ float FGMCAttributeModifier::CalculateModifierValue(const FAttribute& Attribute)
 			}
 		case EModifierType::AddPercentageOfAttributeRawValue:
 			{
-				const float RawValue = SourceAbilityEffect->GetOwnerAbilityComponent()->GetAttributeRawValue(Attribute.Tag);
+				const float RawValue = SourceASC ? SourceASC->GetAttributeRawValue(Attribute.Tag) : Attribute.Value;
 				return TargetValue * RawValue * DeltaTime;
 			}
 		case EModifierType::Set:

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -529,7 +529,7 @@ TArray<FGameplayTag> UGMC_AbilitySystemComponent::GetBoundActiveTagsByParentTag(
 }
 
 bool UGMC_AbilitySystemComponent::TryActivateAbilitiesByInputTag(const FGameplayTag& InputTag, const UInputAction* InputAction,
-	const bool bFromMovementTick, const bool bForce)
+	const bool bFromMovementTick, const bool bForce, const int SourceOperationID)
 {
 
 	auto GrantedAbilities = GetGrantedAbilitiesByTag(InputTag);
@@ -557,23 +557,48 @@ bool UGMC_AbilitySystemComponent::TryActivateAbilitiesByInputTag(const FGameplay
 		}
 	}
 	
-	for (const TSubclassOf<UGMCAbility>& ActivatedAbility : GrantedAbilities)
+	// Operation-derived AbilityIDs: both sides iterate the same granted list (bound
+	// replicated tags) in the same order, so (SourceOperationID, index) names the same
+	// logical activation on client and server.
+	for (int ActivationIndex = 0; ActivationIndex < GrantedAbilities.Num(); ActivationIndex++)
 	{
-		TryActivateAbility(ActivatedAbility, InputAction, InputTag);
+		const int ForcedAbilityID = SourceOperationID != 0
+			? DeriveAbilityIDFromOperation(SourceOperationID, ActivationIndex)
+			: 0;
+		TryActivateAbility(GrantedAbilities[ActivationIndex], InputAction, InputTag, false, ForcedAbilityID);
 	}
 
 	return true;
 }
 
-bool UGMC_AbilitySystemComponent::TryActivateAbility(const TSubclassOf<UGMCAbility> ActivatedAbility, const UInputAction* InputAction, const FGameplayTag ActivationTag, const bool bSkipActivationTagsCheck)
+bool UGMC_AbilitySystemComponent::TryActivateAbility(const TSubclassOf<UGMCAbility> ActivatedAbility, const UInputAction* InputAction, const FGameplayTag ActivationTag, const bool bSkipActivationTagsCheck, const int ForcedAbilityID)
 {
-	
+
 	if (ActivatedAbility == nullptr) return false;
-	
-	
-	// Generated ID is based on ActionTimer so it always lines up on client/server
-	// Also helps when dealing with replays
-	int AbilityID = GenerateAbilityID();
+
+	int AbilityID;
+	if (ForcedAbilityID != 0)
+	{
+		// Operation-derived ID: shared with the remote side by construction (it travels in
+		// the activation payload). If it's already live, this exact logical activation has
+		// already run here — e.g. a client replay re-delivering the same activation op —
+		// so re-running it would create a duplicate instance the other side doesn't have.
+		AbilityID = ForcedAbilityID;
+		if (ActiveAbilities.Contains(AbilityID))
+		{
+			UE_LOG(LogGMCAbilitySystem, Verbose, TEXT("Ability Activation for %s skipped: operation-derived ID %d already active (duplicate delivery/replay)."),
+				*GetNameSafe(ActivatedAbility), AbilityID);
+			return false;
+		}
+	}
+	else
+	{
+		// Fallback for activations with no source operation (server-local: AI, debug).
+		// Generated ID is based on ActionTimer so it tends to line up on client/server,
+		// but it is NOT guaranteed to — paired activations must go through the
+		// operation-derived path above.
+		AbilityID = GenerateAbilityID();
+	}
 
 	const UGMCAbility* AbilityCDO = ActivatedAbility->GetDefaultObject<UGMCAbility>();
 	if (!AbilityCDO->bAllowMultipleInstances)
@@ -591,12 +616,16 @@ bool UGMC_AbilitySystemComponent::TryActivateAbility(const TSubclassOf<UGMCAbili
 		return false;
 	}
 
-	// If multiple abilities are activated on the same frame, add 1 to the ID
-	// This should never actually happen as abilities get queued
-	while (ActiveAbilities.Contains(AbilityID)){
-		AbilityID += 1;
+	// Collision bump for the FALLBACK path only. Never for operation-derived IDs: bumping
+	// would silently rename the activation on one side only, desyncing it from its twin
+	// (the historical root cause of paired confirm-timeout + heartbeat-watchdog kills).
+	if (ForcedAbilityID == 0)
+	{
+		while (ActiveAbilities.Contains(AbilityID)){
+			AbilityID += 1;
+		}
 	}
-	
+
 	UE_LOG(LogGMCAbilitySystem, VeryVerbose, TEXT("[Server: %hhd] Generated Ability Activation ID: %d"), HasAuthority(), AbilityID);
 	
 	UGMCAbility* Ability = NewObject<UGMCAbility>(this, ActivatedAbility);
@@ -1421,12 +1450,37 @@ void UGMC_AbilitySystemComponent::RPCTaskHeartbeat_Implementation(int AbilityID,
 	{
 		ActiveAbilities[AbilityID]->HandleTaskHeartbeat(TaskID);
 	}
+	else
+	{
+		// [TaskDiag] probe: the client is still heartbeating an AbilityID the server no longer
+		// (or never) has. Means the SERVER side ended/diverged first while the client instance
+		// is alive — the reverse of the watchdog scenario. List our live IDs for comparison.
+		// Throttled naturally by the 1/s per-task client send rate.
+		FString LiveIDs;
+		for (const auto& Pair : ActiveAbilities)
+		{
+			LiveIDs += FString::Printf(TEXT("%d(%s) "), Pair.Key, Pair.Value ? *Pair.Value->AbilityTag.ToString() : TEXT("null"));
+		}
+		UE_LOG(LogTemp, Warning,
+			TEXT("[TaskDiag] Heartbeat for unknown AbilityID=%d (TaskID=%d) — client ability alive but server has no such instance. Server live abilities: %s"),
+			AbilityID, TaskID, *LiveIDs);
+	}
 }
 
 void UGMC_AbilitySystemComponent::RPCClientEndAbility_Implementation(int AbilityID)
 {
 	if (ActiveAbilities.Contains(AbilityID))
 	{
+		// [AbilityCut] probe: the server force-ends an ability that is still ACTIVE on this
+		// client — the player-visible "it cut by itself" moment (e.g. server watchdog kill).
+		// An RPC for an already-Ended local instance is routine cleanup and stays quiet.
+		UGMCAbility* LocalAbility = ActiveAbilities[AbilityID];
+		if (LocalAbility && LocalAbility->AbilityState != EAbilityState::Ended)
+		{
+			UE_LOG(LogGMCAbilitySystem, Warning,
+				TEXT("[AbilityCut] Server force-ended ability that was still active locally. %s"),
+				*LocalAbility->GetAbilityCutDiagnostics());
+		}
 		ActiveAbilities[AbilityID]->EndAbility();
 		UE_LOG(LogGMCAbilitySystem, VeryVerbose, TEXT("[RPC] Server Ended Ability: %d"), AbilityID);
 	}
@@ -1668,13 +1722,49 @@ void UGMC_AbilitySystemComponent::ClearAbilityAndTaskData() {
 
 
 void UGMC_AbilitySystemComponent::SendTaskDataToActiveAbility(bool bFromMovement) {
-	
+
 	const FGMCAbilityTaskData TaskDataFromInstance = TaskData.IsValid() ? TaskData.Get<FGMCAbilityTaskData>() : FGMCAbilityTaskData{};
 	if (TaskDataFromInstance != FGMCAbilityTaskData{} && /*safety check*/ TaskDataFromInstance.TaskID >= 0)
 	{
 		if (ActiveAbilities.Contains(TaskDataFromInstance.AbilityID) && ActiveAbilities[TaskDataFromInstance.AbilityID]->bActivateOnMovementTick == bFromMovement)
 		{
+			// [TaskDiag] probe: TaskData is GMC-bound as ClientAuth_Input, so a client replay
+			// restores the historical payload of every replayed move and re-enters this
+			// dispatch — ProgressTask has no replay guard and tasks have no completion guard,
+			// so a replay crossing a Progress-carrying move RE-RUNS the BP continuation
+			// (double Completed broadcast). Log every replayed dispatch to catch it in the act.
+			if (IsReplayingForGMASLogic())
+			{
+				UE_LOG(LogGMCAbilitySystem, Warning,
+					TEXT("[TaskDiag] Progress payload RE-dispatched during replay (AbilityID=%d TaskID=%d fromMovement=%d). %s"),
+					TaskDataFromInstance.AbilityID, TaskDataFromInstance.TaskID, bFromMovement ? 1 : 0,
+					*ActiveAbilities[TaskDataFromInstance.AbilityID]->GetAbilityCutDiagnostics());
+			}
 			ActiveAbilities[TaskDataFromInstance.AbilityID]->HandleTaskData(TaskDataFromInstance.TaskID, TaskData);
+		}
+		else if (!ActiveAbilities.Contains(TaskDataFromInstance.AbilityID))
+		{
+			// [TaskDiag] probe: a valid Progress payload addressed an AbilityID this side does
+			// not have — the payload is silently lost and the addressed task (on the sender's
+			// side or on our twin instance) will never progress. Fires from both the movement
+			// and ancillary dispatch points, so expect up to two lines per lost payload.
+			// During replay this can also be a historical payload for an already-cleaned
+			// ability — the Replaying flag in the message separates the two cases.
+			FString LiveIDs;
+			for (const auto& Pair : ActiveAbilities)
+			{
+				LiveIDs += FString::Printf(TEXT("%d(%s) "), Pair.Key, Pair.Value ? *Pair.Value->AbilityTag.ToString() : TEXT("null"));
+			}
+			UE_LOG(LogGMCAbilitySystem, Warning,
+				TEXT("[TaskDiag] Progress payload lost: AbilityID=%d (TaskID=%d) not in ActiveAbilities (fromMovement=%d Authority=%d Replaying=%d). Live abilities: %s"),
+				TaskDataFromInstance.AbilityID, TaskDataFromInstance.TaskID, bFromMovement ? 1 : 0,
+				HasAuthority() ? 1 : 0, IsReplayingForGMASLogic() ? 1 : 0, *LiveIDs);
+			if (HasAuthority())
+			{
+				UE_LOG(LogTemp, Warning,
+					TEXT("[TaskDiag] Progress payload lost: AbilityID=%d (TaskID=%d) not in ActiveAbilities (fromMovement=%d). Live abilities: %s"),
+					TaskDataFromInstance.AbilityID, TaskDataFromInstance.TaskID, bFromMovement ? 1 : 0, *LiveIDs);
+			}
 		}
 	}
 }
@@ -1753,26 +1843,36 @@ bool UGMC_AbilitySystemComponent::TryActivateClientAuthAbility(
 		return false;
 	}
 
-	// Local activation -- bSkipActivationTagsCheck=true because
-	// CheckActivationTagsForClientAuth already enforced the reduced gate set.
-	const bool bActivated = TryActivateAbility(AbilityClass, InputAction, InputTag,
-		/*bSkipActivationTagsCheck=*/true);
-	if (!bActivated)
-	{
-		return false;
-	}
-
-	// Server-owned pawn? no client->server payload to send.
+	// Server-owned pawn? no client->server payload to send, and no remote twin to pair
+	// with — local ActionTimer-based ID generation is fine.
 	if (HasAuthority())
 	{
-		return true;
+		return TryActivateAbility(AbilityClass, InputAction, InputTag,
+			/*bSkipActivationTagsCheck=*/true);
 	}
 
+	// Build the operation FIRST so the local activation can use the operation-derived
+	// AbilityID — the server's handler derives the same ID from Op.OperationID, which is
+	// what pairs the two instances (heartbeats and task payloads address by AbilityID;
+	// client-auth has no RPCConfirmAbilityActivation to paper over a mismatch).
 	FGMASBoundQueueV2ClientAuthAbilityActivationOperation Op;
 	Op.AbilityClass = AbilityClass;
 	Op.InputTag = InputTag;
 	Op.InputAction = InputAction;
 	const int OpID = BoundQueueV2.MakeOperationData<FGMASBoundQueueV2ClientAuthAbilityActivationOperation>(Op);
+
+	// Local activation -- bSkipActivationTagsCheck=true because
+	// CheckActivationTagsForClientAuth already enforced the reduced gate set.
+	const bool bActivated = TryActivateAbility(AbilityClass, InputAction, InputTag,
+		/*bSkipActivationTagsCheck=*/true,
+		DeriveAbilityIDFromOperation(OpID, 0));
+	if (!bActivated)
+	{
+		// Don't ship an operation whose local activation failed; drop its cached payload.
+		BoundQueueV2.RemovePayloadByID(OpID);
+		return false;
+	}
+
 	BoundQueueV2.QueueClientOperation(OpID);
 	return true;
 }
@@ -1899,7 +1999,25 @@ bool UGMC_AbilitySystemComponent::ProcessOperation(FInstancedStruct OperationDat
 		BoundQueueV2.bInBatchDispatch = true;
 		for (const int32 SubID : Batch.SubOperationIDs)
 		{
-			if (!BoundQueueV2.HasPayloadByID(SubID)) continue;
+			if (!BoundQueueV2.HasPayloadByID(SubID))
+			{
+				// A sub-operation whose payload is missing from the cache (expired, never
+				// delivered) cannot be applied on this side. This used to be a SILENT skip:
+				// the batch still reported success, the op landed on the other side only,
+				// and the resulting state divergence had no trace anywhere. Keep skipping
+				// (nothing to apply) and keep it OUT of the ack list — so the server's
+				// grace-timeout drain still has a chance to force it — but log it loudly.
+				UE_LOG(LogGMCAbilitySystem, Error,
+					TEXT("[BatchOp] Sub-operation %d payload missing from cache — NOT applied on this side (batch of %d sub-ops, Authority=%d, Replaying=%d)."),
+					SubID, Batch.SubOperationIDs.Num(), HasAuthority() ? 1 : 0, IsReplayingForGMASLogic() ? 1 : 0);
+				if (HasAuthority())
+				{
+					UE_LOG(LogTemp, Error,
+						TEXT("[BatchOp] Sub-operation %d payload missing from cache — NOT applied on this side (batch of %d sub-ops)."),
+						SubID, Batch.SubOperationIDs.Num());
+				}
+				continue;
+			}
 
 			FGMASBoundQueueV2OperationBaseData Wrapper;
 			Wrapper.OperationID = SubID;
@@ -1987,7 +2105,9 @@ bool UGMC_AbilitySystemComponent::ProcessOperation(FInstancedStruct OperationDat
 				HasAuthority() ? 1 : 0, bFromMovementTick ? 1 : 0, bForce ? 1 : 0);
 		}
 
-		return TryActivateAbilitiesByInputTag(Data.InputTag, Data.InputAction, bFromMovementTick, bForce);
+		// Thread the operation ID through so AbilityIDs are operation-derived and identical
+		// on client and server (Data.OperationID was stamped once by the queueing side).
+		return TryActivateAbilitiesByInputTag(Data.InputTag, Data.InputAction, bFromMovementTick, bForce, Data.OperationID);
 	}
 
 	// Everything below happens only during the Prediction tick (or via the forced
@@ -2266,6 +2386,24 @@ void UGMC_AbilitySystemComponent::ServerProcessOperation(const FInstancedStruct&
 				return;
 			}
 
+			// Anti-cheat + idempotency: the client-supplied EffectID must be UNIQUE.
+			// ApplyAbilityEffect ends with ActiveEffects.Add(ID, Effect), which silently
+			// OVERWRITES an existing entry — the old instance is orphaned (its modifiers
+			// never rolled back) while the new one ticks. A malicious client replaying the
+			// same ID could stack orphaned modifiers at will; a duplicate delivery of the
+			// same op would corrupt state the same way by accident.
+			if (ActiveEffects.Contains(Op->EffectID))
+			{
+				UE_LOG(LogGMCAbilitySystem, Warning,
+					TEXT("[ServerProcessOperation] ClientAuth effect %s rejected: EffectID %d already active "
+					     "(duplicate delivery or potential cheat attempt)."),
+					*Op->EffectClass->GetName(), Op->EffectID);
+				UE_LOG(LogTemp, Warning,
+					TEXT("[ServerProcessOperation] ClientAuth effect %s rejected: EffectID %d already active."),
+					*Op->EffectClass->GetName(), Op->EffectID);
+				return;
+			}
+
 			// Apply server-side using the client-supplied EffectID for cross-side coherence.
 			FGMCAbilityEffectData InitData = Op->EffectData;
 			InitData.EffectID = Op->EffectID;
@@ -2346,8 +2484,11 @@ void UGMC_AbilitySystemComponent::ServerProcessOperation(const FInstancedStruct&
 				return;
 			}
 
+			// Operation-derived ID so the server instance pairs with the client's local
+			// activation (heartbeats and task payloads address abilities by this ID).
 			TryActivateAbility(Op->AbilityClass, Op->InputAction, Op->InputTag,
-				/*bSkipActivationTagsCheck=*/true);
+				/*bSkipActivationTagsCheck=*/true,
+				DeriveAbilityIDFromOperation(Op->OperationID, 0));
 			// No RPCConfirmAbilityActivation -- client trusts the activation by construction.
 			return;
 		}
@@ -2433,22 +2574,34 @@ void UGMC_AbilitySystemComponent::CheckUnBoundAttributeChanged()
 	TArray<FAttribute>& OldAttributes = OldUnBoundAttributes.Items;
 	const TArray<FAttribute>& CurrentAttributes = UnBoundAttributes.Items;
 
-	TMap<FGameplayTag, float*> OldValues;
+	// Two-phase by VALUE: collect changes and sync the old set FIRST, broadcast LAST.
+	// The previous implementation held float* into OldAttributes across the delegate
+	// broadcasts — any handler mutating the unbound attribute set (add/remove) reallocates
+	// the TArray and every remaining pointer dangles. It also iterated the live
+	// CurrentAttributes array while broadcasting, with the same re-entrancy hazard.
+	struct FAttributeChange { FGameplayTag Tag; float OldValue; float NewValue; };
+	TArray<FAttributeChange> Changes;
 
-	// If this mitchmatch, that mean we need to reset the number of attributes
-	
-	for (FAttribute& Attribute : OldAttributes){
-		OldValues.Add(Attribute.Tag, &Attribute.Value);
-	}
-	
-	for (const FAttribute& Attribute : CurrentAttributes){
-		if (OldValues.Contains(Attribute.Tag) && *OldValues[Attribute.Tag] != Attribute.Value){
-			NativeAttributeChangeDelegate.Broadcast(Attribute.Tag, *OldValues[Attribute.Tag], Attribute.Value);
-			OnAttributeChanged.Broadcast(Attribute.Tag, *OldValues[Attribute.Tag], Attribute.Value);
-
-			// Update Old Value
-			*OldValues[Attribute.Tag] = Attribute.Value;
+	for (const FAttribute& Attribute : CurrentAttributes)
+	{
+		for (FAttribute& OldAttribute : OldAttributes)
+		{
+			if (OldAttribute.Tag == Attribute.Tag)
+			{
+				if (OldAttribute.Value != Attribute.Value)
+				{
+					Changes.Add({ Attribute.Tag, OldAttribute.Value, Attribute.Value });
+					OldAttribute.Value = Attribute.Value;
+				}
+				break;
+			}
 		}
+	}
+
+	for (const FAttributeChange& Change : Changes)
+	{
+		NativeAttributeChangeDelegate.Broadcast(Change.Tag, Change.OldValue, Change.NewValue);
+		OnAttributeChanged.Broadcast(Change.Tag, Change.OldValue, Change.NewValue);
 	}
 }
 
@@ -3074,17 +3227,26 @@ void UGMC_AbilitySystemComponent::RemoveActiveAbilityEffectByTag(const FGameplay
 
 	if (!Tag.IsValid()) return;
 
-	for (auto& [EffectId, Effect] : ActiveEffects)
+	// Snapshot matching IDs before removing: RemoveEffectByIdSafe can run EndEffect
+	// synchronously, and an OnEffectEnded handler that applies a new effect re-enters
+	// ActiveEffects.Add mid-iteration — mutating the TMap invalidates this loop's iterator.
+	// Same snapshot pattern as RemoveEffectByTagSafe / EffectsMatchingTag.
+	TArray<int> MatchingIds;
+	for (const auto& [EffectId, Effect] : ActiveEffects)
 	{
 		if (IsValid(Effect) && Effect->EffectData.EffectTag.MatchesTag(Tag))
 		{
-			RemoveEffectByIdSafe({ EffectId }, QueueType);
+			MatchingIds.Add(EffectId);
 			if (!bAllInstance) {
-				return;
+				break;
 			}
 		}
 	}
-	
+
+	if (MatchingIds.Num() > 0)
+	{
+		RemoveEffectByIdSafe(MatchingIds, QueueType);
+	}
 }
 
 TArray<int> UGMC_AbilitySystemComponent::EffectsMatchingTag(const FGameplayTag& Tag, int32 NumToRemove) const

--- a/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
+++ b/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
@@ -287,17 +287,24 @@ void UGMCAbilityEffect::Tick(float DeltaTime)
 		} // End Ticking
 		else if (EffectData.EffectType == EGMASEffectType::Periodic)
 		{
-			
+			// STATELESS period detection on purpose: the crossing test is a pure function of
+			// (ActionTimer, StartTime, DeltaTime). Per-move windows tile exactly (move N's end
+			// is move N+1's start), so boundaries are counted once and exactly once — and a
+			// client replay re-executes the same moves with the same stored DeltaTimes, so it
+			// recomputes the SAME boundary crossings (bound attributes were rolled back, so
+			// re-applying is the prediction model working as intended). Do NOT introduce
+			// per-effect accumulators here (e.g. pause-time shifting): they would mutate
+			// during replayed ticks without being rolled back and desync client from server.
 			const float CurrentElapsedTime = OwnerAbilityComponent->ActionTimer -  EffectData.StartTime;
 			float PreviousElapsedTime = CurrentElapsedTime - DeltaTime;
 			PreviousElapsedTime = FMath::Max(PreviousElapsedTime, 0.f); // Ensure we don't go negative
 
 			int32 PreviousPeriod = FMath::TruncToInt(PreviousElapsedTime / EffectData.PeriodicInterval);
 			int32 CurrentPeriod =	FMath::TruncToInt(CurrentElapsedTime / EffectData.PeriodicInterval);
-			
+
 			if (CurrentPeriod > PreviousPeriod) {
 				int32 NumTickToApply = CurrentPeriod - PreviousPeriod;
-				
+
 				for (int i = 0; i < NumTickToApply; i++) {
 					for (int y = 0; y < EffectData.Modifiers.Num(); y++) {
 						FGMCAttributeModifier Modifier = EffectData.Modifiers[y];
@@ -312,7 +319,28 @@ void UGMCAbilityEffect::Tick(float DeltaTime)
 					PeriodTick();
 				}
 			}
-			
+
+		}
+	}
+	else if (CurrentState == EGMASEffectState::Started
+		&& EffectData.EffectType == EGMASEffectType::Periodic
+		&& (IsPaused() || !AttributeDynamicCondition()))
+	{
+		// Period boundaries crossed while paused (or while the dynamic condition is false)
+		// are DROPPED, not deferred — the schedule stays anchored on StartTime, so the next
+		// application happens at the next absolute boundary after resume. This is a design
+		// constraint, not an oversight: deferring would need a paused-time accumulator,
+		// which cannot be made replay-safe (see the stateless-detection comment above).
+		// Log the drops so balance-affecting pauses are visible instead of silent.
+		const float CurrentElapsedTime = OwnerAbilityComponent->ActionTimer - EffectData.StartTime;
+		const float PreviousElapsedTime = FMath::Max(CurrentElapsedTime - DeltaTime, 0.f);
+		const int32 SkippedTicks = FMath::TruncToInt(CurrentElapsedTime / EffectData.PeriodicInterval)
+			- FMath::TruncToInt(PreviousElapsedTime / EffectData.PeriodicInterval);
+		if (SkippedTicks > 0)
+		{
+			UE_LOG(LogGMCAbilitySystem, Verbose,
+				TEXT("Periodic effect %s dropped %d tick(s) while %s (by design — boundaries are not deferred)."),
+				*GetName(), SkippedTicks, IsPaused() ? TEXT("paused") : TEXT("dynamic condition false"));
 		}
 	}
 

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
@@ -59,6 +59,12 @@ public:
 	void RegisterTask(int Id, UGMCAbilityTaskBase* Task) {RunningTasks.Add(Id, Task);}
 	void TickTasks(float DeltaTime);
 	void AncillaryTickTasks(float DeltaTime);
+
+	// Multi-line diagnostic snapshot of this ability and every registered task (state,
+	// completion, heartbeat counters/ages). Built for the [AbilityCut]/[TaskDiag] logs that
+	// fire when an ability dies abnormally — answers "what was still running, what had the
+	// server/client seen, and were we replaying" without needing a debugger attached.
+	FString GetAbilityCutDiagnostics() const;
 	
 	void Execute(UGMC_AbilitySystemComponent* InAbilityComponent, int InAbilityID, const UInputAction* InputAction = nullptr);
 	

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/GMCAbilityTaskBase.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/GMCAbilityTaskBase.h
@@ -61,12 +61,20 @@ public:
 
 	// Called when client requests to progress task. Task must make sure this is handled properly/securely
 	virtual void ProgressTask(FInstancedStruct& TaskData){};
-	
+
 	// Client calling to progress the task forward
 	// Task must make sure this is handled properly
 	virtual void ClientProgressTask();
-	
+
 	virtual void Heartbeat();
+
+	// Diagnostic accessors for the ability-cut instrumentation ([AbilityCut]/[TaskDiag] logs).
+	// Expose internal liveness state so UGMCAbility can dump every task when an ability dies
+	// abnormally. Read-only; no behavior impact.
+	bool IsTaskCompleted() const { return bTaskCompleted; }
+	int32 GetHeartbeatReceivedCount() const { return HeartbeatReceivedCount; }
+	double GetLastHeartbeatReceivedTime() const { return LastHeartbeatReceivedTime; }
+	double GetClientLastHeartbeatSentTime() const { return ClientLastHeartbeatSentTime; }
 
 protected:
 	bool bTaskCompleted;

--- a/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
+++ b/Source/GMCAbilitySystem/Public/Components/GMCAbilityComponent.h
@@ -430,15 +430,20 @@ public:
 	TArray<TSubclassOf<UGMCAbilityEffect>> ClientAuthorizedAbilityEffects;
 
 	// Do not call directly on client, go through QueueAbility
-	bool TryActivateAbilitiesByInputTag(const FGameplayTag& InputTag, const UInputAction* InputAction = nullptr, const bool bFromMovementTick=true, const bool bForce=false);
-	
+	// SourceOperationID: BoundQueueV2 operation that carried this activation (0 = none).
+	// When set, AbilityIDs are derived from it so client and server agree by construction.
+	bool TryActivateAbilitiesByInputTag(const FGameplayTag& InputTag, const UInputAction* InputAction = nullptr, const bool bFromMovementTick=true, const bool bForce=false, const int SourceOperationID = 0);
+
 	// Do not call directly on client, go through QueueAbility. Can be used to call server-side abilities (like AI).
 	// bSkipActivationTagsCheck=true bypasses CheckActivationTags(CDO). Used by the
 	// client-auth path; default false preserves all existing call sites.
+	// ForcedAbilityID: operation-derived ID shared by client and server (0 = generate
+	// locally from ActionTimer — only safe for activations with no remote twin, e.g. AI).
 	bool TryActivateAbility(TSubclassOf<UGMCAbility> ActivatedAbility,
 	                        const UInputAction* InputAction = nullptr,
 	                        const FGameplayTag ActivationTag = FGameplayTag::EmptyTag,
-	                        bool bSkipActivationTagsCheck = false);
+	                        bool bSkipActivationTagsCheck = false,
+	                        const int ForcedAbilityID = 0);
 
 
 	/**
@@ -1002,7 +1007,24 @@ private:
 	TMap<FGameplayTag, double> ActiveCooldowns;
 
 	int GenerateAbilityID() const {return ActionTimer * 100;}
-	
+
+	// Derive a client/server-identical AbilityID from a BoundQueueV2 operation. The
+	// OperationID is generated once by the queueing side and travels inside the operation
+	// payload, so both sides read the same value — unlike GenerateAbilityID + the local
+	// collision bump (`while (Contains) ID += 1`), whose result depends on each side's
+	// ActiveAbilities content and diverges under rapid re-activation (observed as paired
+	// confirm-timeout + heartbeat-watchdog kills).
+	// 16 slots per operation: one activation op may activate several granted ability
+	// classes; both sides iterate the granted list in the same order. Slot layout keeps
+	// client (negative) and server (positive) operations in disjoint ranges:
+	// op 1 -> [16..31], op 2 -> [32..47] ; op -1 -> [-16..-31], op -2 -> [-32..-47].
+	// 0 is the "no source operation" sentinel (local ActionTimer generation).
+	static int DeriveAbilityIDFromOperation(const int OperationID, const int ActivationIndex)
+	{
+		return OperationID * 16 + (OperationID < 0 ? -ActivationIndex : ActivationIndex);
+	}
+
+
 	// Set Attributes to either a default object or a provided TSubClassOf<UGMCAttributeSet> in BP defaults
 	// This must run before variable binding
 	void InstantiateAttributes();

--- a/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
+++ b/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
@@ -241,12 +241,13 @@ class GMCABILITYSYSTEM_API UGMCAbilityEffect : public UObject
 {
 	GENERATED_BODY()
 
+public:
+	// Public on purpose: GENERATED_BODY() resets access to private, which silently made this
+	// override private and broke Super::PostEditChangeProperty() calls in derived classes
+	// (C2248). UObject declares it public — keep the same visibility.
 #if WITH_EDITOR
 	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;
 #endif
-	
-
-public:
 	EGMASEffectState CurrentState = EGMASEffectState::Initialized;
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "GMCAbilitySystem")


### PR DESCRIPTION
## Summary

Three commits made on the engine submodule pin (detached from `773c8ea`, now pushed as this branch so the pin stays resolvable):

- **fix(attributes): guard stale `SourceAbilityEffect` in attribute-driven modifier math** — `SourceAbilityEffect` is a `TWeakObjectPtr`; a modifier kept in the attribute's temporal history can outlive its effect (GC after `EndEffect`), and every attribute-driven op (`AddPercentageAttribute`, clamp-tag reads, attribute sums) dereferenced it raw. The source ASC is now resolved once, validated, with a logged 0-fallback instead of a crash.
- **fix(effects): restore `PostEditChangeProperty` visibility + log dropped periodic ticks** — `GENERATED_BODY()` resets access to private, silently making the override private and breaking `Super::` calls in derived classes (C2248). Also documents why periodic-effect boundary detection is stateless on purpose (replay safety) and logs boundaries dropped while paused / condition-false.
- **feat(diag): `[AbilityCut]`/`[TaskDiag]` probes for held abilities dying abnormally** — instrumentation to harvest the held-ability self-cut bug (heal cutting itself) from real session logs: per-ability/task diagnostic dumps, heartbeat send/receive counters on the wait-input tasks, replay re-dispatch traces, TaskID-divergence smoking-gun logs, loud `[BatchOp]` errors on missing sub-operation payloads. Structural fixes deliberately deferred until logs are harvested.

## Merge notes

⚠️ This branch diverges from `dev` at `0b81e08`: `dev` has the tag-driven conditional modifiers (`a8668a5`) and the grace-time fix (`6d9e2c0`), which touch the same files (`GMCAbilityEffect.h/.cpp`, `GMCAbilityComponent.cpp`, `GMCAttributeModifier.cpp`). Expect conflicts — resolve keeping BOTH the conditional-modifier feature and these guards/probes. The engine submodule currently pins this branch's tip (`165284d`); after merging, re-pin the engine to the merge commit.

## Test plan

- [ ] Build editor + dedicated server with the plugin
- [ ] PIE 2-player: held heal ability, watch `[AbilityCut]`/`[TaskDiag]` output
- [ ] Verify no C2248 on derived effect classes overriding `PostEditChangeProperty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Fixed potential crashes during player possession transitions in input handling
* Prevented duplicate task completion execution from re-entrant handlers
* Added safety guards for invalid ability and task states during network replay
* Improved periodic effect boundary crossing detection to prevent deferred ticks
* Added duplicate effect prevention for improved network coherency

**New Features**
* Enhanced diagnostic logging for ability timeouts and unfinished tasks to aid troubleshooting
* Deterministic ability ID derivation from network operations for improved replay reliability

**Performance**
* Optimized attribute modifier calculations by reducing redundant component lookups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->