### PR TITLE
fix(tasks): purge finished tasks from RunningTasks and stop dead-task watchdogs

### DIFF
--- a/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/GMCAbility.cpp
@@ -117,6 +117,9 @@ void UGMCAbility::Tick(float DeltaTime)
 	}
 
 	TickTasks(DeltaTime);
+	// A task ending itself mid-pass (or its Completed BP) can have ended the whole ability;
+	// don't fire the BP tick on a dead ability.
+	if (AbilityState == EAbilityState::Ended) return;
 	TickEvent(DeltaTime);
 }
 
@@ -124,22 +127,84 @@ void UGMCAbility::AncillaryTick(float DeltaTime) {
 	// Don't tick before the ability is initialized or after it has ended
 	if (AbilityState == EAbilityState::PreExecution || AbilityState == EAbilityState::Ended) return;
 
+	// [TaskDiag] census: with finished tasks unregistering themselves from RunningTasks, a
+	// server ability whose tasks ALL ended but whose graph never calls EndAbility has zero
+	// task-level liveness coverage left (the old ghost-task watchdog reaped it by accident).
+	// Don't auto-kill — the false-kill cure must not become a new kill path — but make the
+	// leak visible: one line once the ability has been task-less for two watchdog periods.
+	// Server net modes only, remote pawns only (local server pawns never ran the watchdog).
+	if (!bTasklessCensusLogged && TaskIDCounter >= 0 && OwnerAbilityComponent
+		&& (OwnerAbilityComponent->GetNetMode() == NM_DedicatedServer || OwnerAbilityComponent->GetNetMode() == NM_ListenServer)
+		&& OwnerAbilityComponent->GMCMovementComponent
+		&& !OwnerAbilityComponent->GMCMovementComponent->IsLocallyControlledServerPawn())
+	{
+		bool bHasLiveTask = false;
+		for (const TPair<int, UGMCAbilityTaskBase*>& TaskPair : RunningTasks)
+		{
+			if (TaskPair.Value && TaskPair.Value->GetState() != EGameplayTaskState::Finished)
+			{
+				bHasLiveTask = true;
+				break;
+			}
+		}
+		if (bHasLiveTask)
+		{
+			TasklessSinceTime = 0.0;
+		}
+		else
+		{
+			const double Now = FPlatformTime::Seconds();
+			if (TasklessSinceTime == 0.0)
+			{
+				TasklessSinceTime = Now;
+			}
+			else if (Now - TasklessSinceTime > 6.0) // 2x the task watchdog interval
+			{
+				// Neutral wording on purpose: abilities ended externally (cancel-by-tag, effect
+				// removal) legitimately idle task-less — this is coverage info, not an accusation.
+				const FString Diag = GetAbilityCutDiagnostics();
+				UE_LOG(LogGMCAbilitySystem, Warning,
+					TEXT("[TaskDiag] Ability task-less for %.1fs and still active — no task-level liveness coverage (may be by design for externally-ended abilities). %s"),
+					Now - TasklessSinceTime, *Diag);
+				UE_LOG(LogTemp, Warning,
+					TEXT("[TaskDiag] Ability task-less for %.1fs and still active — no task-level liveness coverage (may be by design for externally-ended abilities). %s"),
+					Now - TasklessSinceTime, *Diag);
+				bTasklessCensusLogged = true;
+			}
+		}
+	}
+
 	AncillaryTickTasks(DeltaTime);
+	// The heartbeat watchdog inside AncillaryTickTasks can have ended the whole ability;
+	// don't fire the BP tick on a dead ability.
+	if (AbilityState == EAbilityState::Ended) return;
 	AncillaryTickEvent(DeltaTime);
 }
 
 void UGMCAbility::TickTasks(float DeltaTime)
 {
-	for (auto& [Id, Task] : RunningTasks)
+	// Iterate a snapshot, never the live map: tasks end themselves mid-tick (WaitDelay & co)
+	// and unregister from RunningTasks in OnDestroy, and Completed broadcasts can run BP that
+	// registers NEW tasks — both mutate the map under a live range-for. The per-entry Finished
+	// check covers tasks mass-ended earlier in this same pass (watchdog -> EndAbility).
+	TArray<UGMCAbilityTaskBase*, TInlineAllocator<8>> TasksSnapshot;
+	RunningTasks.GenerateValueArray(TasksSnapshot);
+	for (UGMCAbilityTaskBase* Task : TasksSnapshot)
 	{
-		if (Task) Task->Tick(DeltaTime);
+		if (!Task || Task->GetState() == EGameplayTaskState::Finished) continue;
+		Task->Tick(DeltaTime);
 	}
 }
 
 void UGMCAbility::AncillaryTickTasks(float DeltaTime) {
-	for (auto& [Id, Task] : RunningTasks)
+	// Same snapshot rationale as TickTasks — the watchdog inside AncillaryTick can end the
+	// whole ability (mass task unregistration) while this loop is running.
+	TArray<UGMCAbilityTaskBase*, TInlineAllocator<8>> TasksSnapshot;
+	RunningTasks.GenerateValueArray(TasksSnapshot);
+	for (UGMCAbilityTaskBase* Task : TasksSnapshot)
 	{
-		if (Task) Task->AncillaryTick(DeltaTime);
+		if (!Task || Task->GetState() == EGameplayTaskState::Finished) continue;
+		Task->AncillaryTick(DeltaTime);
 	}
 }
 
@@ -243,21 +308,33 @@ void UGMCAbility::HandleTaskData(int TaskID, FInstancedStruct TaskData)
 			Task->ProgressTask(TaskData);
 		}
 	}
+	else if (TaskID <= TaskIDCounter)
+	{
+		// TaskIDs are monotonic and never reused, so an ID at or below the counter was issued
+		// here and its task already ended and unregistered — usually a benign late/replayed
+		// re-delivery racing the purge (the payload is correctly ignored either way). Caveat:
+		// a SHIFTED-ID divergence (both sides issued this numeric ID for different logical
+		// tasks) is indistinguishable here — don't rule divergence out on this line alone.
+		UE_LOG(LogGMCAbilitySystem, Verbose,
+			TEXT("[TaskDiag] Progress payload for already-unregistered TaskID=%d ignored (benign end race, Replaying=%d)."),
+			TaskID, OwnerAbilityComponent && OwnerAbilityComponent->IsReplayingForGMASLogic() ? 1 : 0);
+	}
 	else
 	{
-		// [TaskDiag] probe: a Progress payload arrived for a TaskID this side never registered
-		// (or already dropped). This is the silent dispatch failure that leaves the other
-		// side's task waiting forever — TaskIDs are independent per-side counters, so any
-		// asymmetric task creation (e.g. a BP branch firing on one side only, or a replay
+		// [TaskDiag] probe: a Progress payload arrived for a TaskID this side NEVER issued
+		// (above our monotonic counter). This is the silent dispatch failure that leaves the
+		// other side's task waiting forever — TaskIDs are independent per-side counters, so
+		// any asymmetric task creation (e.g. a BP branch firing on one side only, or a replay
 		// double-executing a graph) shifts every subsequent ID.
+		const FString Diag = GetAbilityCutDiagnostics();
 		UE_LOG(LogGMCAbilitySystem, Warning,
-			TEXT("[TaskDiag] Progress payload dropped: TaskID=%d not in RunningTasks. %s"),
-			TaskID, *GetAbilityCutDiagnostics());
+			TEXT("[TaskDiag] Progress payload dropped: TaskID=%d never issued on this side (max issued %d) — TaskID divergence. %s"),
+			TaskID, TaskIDCounter, *Diag);
 		if (OwnerAbilityComponent && OwnerAbilityComponent->HasAuthority())
 		{
 			UE_LOG(LogTemp, Warning,
-				TEXT("[TaskDiag] Progress payload dropped: TaskID=%d not in RunningTasks. %s"),
-				TaskID, *GetAbilityCutDiagnostics());
+				TEXT("[TaskDiag] Progress payload dropped: TaskID=%d never issued on this side (max issued %d) — TaskID divergence. %s"),
+				TaskID, TaskIDCounter, *Diag);
 		}
 	}
 }
@@ -268,21 +345,36 @@ void UGMCAbility::HandleTaskHeartbeat(int TaskID)
 	{
 		RunningTasks[TaskID]->Heartbeat();
 	}
-	else
+	else if (TaskID <= TaskIDCounter)
 	{
-		// [TaskDiag] probe: the client is heartbeating a TaskID the server doesn't have.
-		// The client-side ability is alive (it sent this) but its task layout diverged from
-		// ours — the matching server task is starving and the watchdog will cancel the
-		// ability within HeartbeatMaxInterval. Throttled naturally by the 1/s send rate.
+		// Heartbeat for a task we issued and already ended/unregistered — the sender's twin
+		// just hasn't ended yet (up to one-way transit + the 1s send cadence). Benign.
+		UE_LOG(LogGMCAbilitySystem, Verbose,
+			TEXT("[TaskDiag] Heartbeat for already-unregistered TaskID=%d ignored (benign end race)."), TaskID);
+	}
+	else if (!WarnedDivergentTaskIDs.Contains(TaskID))
+	{
+		// [TaskDiag] probe: the sender is heartbeating a TaskID this side NEVER issued (above
+		// our monotonic counter) — its task layout diverged from ours. If a real twin was
+		// expected here it is starving and the watchdog will cancel the ability; an APPENDED
+		// extra task (e.g. created client-side during replay) starves nothing and just keeps
+		// beating. Warn once per TaskID — repeats at the 1/s send rate go Verbose below.
+		WarnedDivergentTaskIDs.Add(TaskID);
+		const FString Diag = GetAbilityCutDiagnostics();
 		UE_LOG(LogGMCAbilitySystem, Warning,
-			TEXT("[TaskDiag] Heartbeat for unknown TaskID=%d. %s"),
-			TaskID, *GetAbilityCutDiagnostics());
+			TEXT("[TaskDiag] Heartbeat for TaskID=%d never issued on this side (max issued %d) — TaskID divergence. %s"),
+			TaskID, TaskIDCounter, *Diag);
 		if (OwnerAbilityComponent && OwnerAbilityComponent->HasAuthority())
 		{
 			UE_LOG(LogTemp, Warning,
-				TEXT("[TaskDiag] Heartbeat for unknown TaskID=%d. %s"),
-				TaskID, *GetAbilityCutDiagnostics());
+				TEXT("[TaskDiag] Heartbeat for TaskID=%d never issued on this side (max issued %d) — TaskID divergence. %s"),
+				TaskID, TaskIDCounter, *Diag);
 		}
+	}
+	else
+	{
+		UE_LOG(LogGMCAbilitySystem, Verbose,
+			TEXT("[TaskDiag] Heartbeat for divergent TaskID=%d (already warned)."), TaskID);
 	}
 }
 
@@ -388,23 +480,29 @@ void UGMCAbility::FinishEndAbility() {
 	}
 	if (UnfinishedTasks > 0)
 	{
+		const FString Diag = GetAbilityCutDiagnostics();
 		UE_LOG(LogGMCAbilitySystem, Warning,
 			TEXT("[AbilityCut] Ability ending with %d unfinished task(s). %s"),
-			UnfinishedTasks, *GetAbilityCutDiagnostics());
+			UnfinishedTasks, *Diag);
 		// Mirror onto LogTemp: the dedicated-server log export only ships a fixed category
 		// allowlist (LogTemp included, LogGMCAbilitySystem not).
 		if (OwnerAbilityComponent && OwnerAbilityComponent->HasAuthority())
 		{
 			UE_LOG(LogTemp, Warning,
 				TEXT("[AbilityCut] Ability ending with %d unfinished task(s). %s"),
-				UnfinishedTasks, *GetAbilityCutDiagnostics());
+				UnfinishedTasks, *Diag);
 		}
 	}
 
-	for (const TPair<int, UGMCAbilityTaskBase* >& Task : RunningTasks)
+	// Snapshot: EndTaskGMAS -> EndTask -> OnDestroy unregisters the entry being visited,
+	// which would invalidate a live range-for over the map. EndTask itself is idempotent
+	// (engine-guarded on TaskState != Finished), so re-ending a task is a safe no-op.
+	TArray<UGMCAbilityTaskBase*, TInlineAllocator<8>> TasksToEnd;
+	RunningTasks.GenerateValueArray(TasksToEnd);
+	for (UGMCAbilityTaskBase* Task : TasksToEnd)
 	{
-		if (Task.Value == nullptr) continue;
-		Task.Value->EndTaskGMAS();
+		if (Task == nullptr) continue;
+		Task->EndTaskGMAS();
 	}
 
 	// End handled effect

--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/GMCAbilityTaskBase.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/GMCAbilityTaskBase.cpp
@@ -32,6 +32,19 @@ void UGMCAbilityTaskBase::EndTaskGMAS()
 	EndTask();
 }
 
+void UGMCAbilityTaskBase::OnDestroy(bool bInOwnerFinished)
+{
+	// Unregister BEFORE Super (which marks this object garbage). The value check is mandatory:
+	// a never-activated task still carries the zero-init TaskID of 0, which aliases the first
+	// real registered task — a bare Remove(TaskID) would evict that live task and silence its
+	// heartbeats, recreating the very starvation bug this purge exists to fix.
+	if (Ability && Ability->RunningTasks.FindRef(TaskID) == this)
+	{
+		Ability->RunningTasks.Remove(TaskID);
+	}
+	Super::OnDestroy(bInOwnerFinished);
+}
+
 void UGMCAbilityTaskBase::SetAbilitySystemComponent(UGMC_AbilitySystemComponent* InAbilitySystemComponent)
 {
 	this->AbilitySystemComponent = InAbilitySystemComponent;
@@ -52,6 +65,12 @@ void UGMCAbilityTaskBase::AncillaryTick(float DeltaTime){
 	// AbilitySystemComponent is a TWeakObjectPtr: during pawn teardown / possession change the
 	// component can die while this task is still registered, and a stale dereference crashes.
 	if (!AbilitySystemComponent.IsValid() || !AbilitySystemComponent->GMCMovementComponent) return;
+
+	// A task that already ended must neither heartbeat nor watchdog: its twin's lifetime is no
+	// longer tied to ours. Without this, a Finished-but-still-registered server task keeps its
+	// watchdog armed while the destroyed client twin no longer heartbeats — the watchdog then
+	// kills a healthy ability on a pure GC-timing race (proven heal-cut bug, 2026-06-12).
+	if (GetState() == EGameplayTaskState::Finished || bTaskCompleted) return;
 
 	// Locally controlled server pawns don't need to send heartbeats
 	if (AbilitySystemComponent->GMCMovementComponent->IsLocallyControlledServerPawn()) return;
@@ -115,6 +134,10 @@ void UGMCAbilityTaskBase::Heartbeat()
 
 bool UGMCAbilityTaskBase::IsClientOrRemoteListenServerPawn() const
 {
+	// Null-safe: derived AncillaryTick bodies keep executing after the base early-returns on a
+	// dead component, so this helper must not assume the weak-ptr guard already passed.
+	if (!AbilitySystemComponent.IsValid() || !AbilitySystemComponent->GMCMovementComponent) return false;
+
 	return (AbilitySystemComponent->GetNetMode() != NM_DedicatedServer &&
 		AbilitySystemComponent->GetNetMode() != NM_ListenServer) ||
 		AbilitySystemComponent->GMCMovementComponent->IsLocallyControlledServerPawn();

--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyPress.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyPress.cpp
@@ -76,7 +76,15 @@ void UGMCAbilityTask_WaitForInputKeyPress::AncillaryTick(float DeltaTime)
 
 	if (MaxDuration > 0 && Duration >= MaxDuration)
 	{
-		ClientProgressTask();
+		// Progress push only where a queue drain exists (owning client / listen host): on a
+		// dedicated server this re-queued every ancillary tick into QueuedTaskData, which is
+		// never drained for remote pawns — unbounded growth for the remaining ability life.
+		// bTimedOut must still latch server-side so the payload-driven OnTaskCompleted picks
+		// the TimedOut broadcast on both machines.
+		if (IsClientOrRemoteListenServerPawn())
+		{
+			ClientProgressTask();
+		}
 		bTimedOut = true;
 	}
 }
@@ -116,6 +124,16 @@ void UGMCAbilityTask_WaitForInputKeyPress::OnTaskCompleted()
 
 	EndTask();
 	Duration = AbilitySystemComponent->ActionTimer - StartTime;
+	// Deterministic timeout decision: the ancillary-tick latch races the payload dispatch
+	// across machines (the server's latch runs AFTER the payload dispatch point, so when the
+	// threshold-crossing move and the payload-carrying move batch into the same server frame,
+	// the server would read a stale bTimedOut=false while the client latched true). Re-derive
+	// from the payload-move ActionTimer, which both machines share, so Completed vs TimedOut
+	// never diverges.
+	if (!bTimedOut && MaxDuration > 0 && Duration >= MaxDuration)
+	{
+		bTimedOut = true;
+	}
 	if (!bTimedOut)
 	{
 		Completed.Broadcast(Duration);
@@ -128,9 +146,8 @@ void UGMCAbilityTask_WaitForInputKeyPress::OnTaskCompleted()
 
 void UGMCAbilityTask_WaitForInputKeyPress::OnDestroy(bool bInOwnerFinished)
 {
-	Super::OnDestroy(bInOwnerFinished);
-
 	// If we're still bound to the input component for some reason, we'll want to unbind.
+	// Done BEFORE Super per the engine contract ("call Super::OnDestroy as the last thing").
 	if (InputBindingHandle != -1)
 	{
 		if (InputComponent)
@@ -139,6 +156,8 @@ void UGMCAbilityTask_WaitForInputKeyPress::OnDestroy(bool bInOwnerFinished)
 			InputBindingHandle = -1;
 		}
 	}
+
+	Super::OnDestroy(bInOwnerFinished);
 }
 
 void UGMCAbilityTask_WaitForInputKeyPress::ProgressTask(FInstancedStruct& TaskData)

--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyPressParameterized.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyPressParameterized.cpp
@@ -73,10 +73,18 @@ void UGMCAbilityTask_WaitForInputKeyPressParameterized::AncillaryTick(float Delt
 
 	if (MaxDuration > 0 && Duration >= MaxDuration)
 	{
-		ClientProgressTask();
+		// Progress push only where a queue drain exists (owning client / listen host): on a
+		// dedicated server this re-queued every ancillary tick into QueuedTaskData, which is
+		// never drained for remote pawns — unbounded growth for the remaining ability life.
+		// bTimedOut must still latch server-side so the payload-driven OnTaskCompleted picks
+		// the TimedOut broadcast on both machines.
+		if (IsClientOrRemoteListenServerPawn())
+		{
+			ClientProgressTask();
+		}
 		bTimedOut = true;
 	}
-	
+
 }
 
 void UGMCAbilityTask_WaitForInputKeyPressParameterized::OnKeyPressed(const FInputActionValue& InputActionValue)
@@ -113,6 +121,16 @@ void UGMCAbilityTask_WaitForInputKeyPressParameterized::OnTaskCompleted()
 
 	EndTask();
 	Duration = AbilitySystemComponent->ActionTimer - StartTime;
+	// Deterministic timeout decision: the ancillary-tick latch races the payload dispatch
+	// across machines (the server's latch runs AFTER the payload dispatch point, so when the
+	// threshold-crossing move and the payload-carrying move batch into the same server frame,
+	// the server would read a stale bTimedOut=false while the client latched true). Re-derive
+	// from the payload-move ActionTimer, which both machines share, so Completed vs TimedOut
+	// never diverges.
+	if (!bTimedOut && MaxDuration > 0 && Duration >= MaxDuration)
+	{
+		bTimedOut = true;
+	}
 	if (!bTimedOut)
 	{
 		Completed.Broadcast(Duration);
@@ -125,9 +143,8 @@ void UGMCAbilityTask_WaitForInputKeyPressParameterized::OnTaskCompleted()
 
 void UGMCAbilityTask_WaitForInputKeyPressParameterized::OnDestroy(bool bInOwnerFinished)
 {
-	Super::OnDestroy(bInOwnerFinished);
-
 	// If we're still bound to the input component for some reason, we'll want to unbind.
+	// Done BEFORE Super per the engine contract ("call Super::OnDestroy as the last thing").
 	if (InputBindingHandle != -1)
 	{
 		if (InputComponent)
@@ -136,6 +153,8 @@ void UGMCAbilityTask_WaitForInputKeyPressParameterized::OnDestroy(bool bInOwnerF
 			InputBindingHandle = -1;
 		}
 	}
+
+	Super::OnDestroy(bInOwnerFinished);
 }
 
 void UGMCAbilityTask_WaitForInputKeyPressParameterized::ProgressTask(FInstancedStruct& TaskData)

--- a/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyRelease.cpp
+++ b/Source/GMCAbilitySystem/Private/Ability/Tasks/WaitForInputKeyRelease.cpp
@@ -81,7 +81,15 @@ void UGMCAbilityTask_WaitForInputKeyRelease::AncillaryTick(float DeltaTime)
 
 	if (MaxDuration > 0 && Duration >= MaxDuration)
 	{
-		ClientProgressTask();
+		// Progress push only where a queue drain exists (owning client / listen host): on a
+		// dedicated server this re-queued every ancillary tick into QueuedTaskData, which is
+		// never drained for remote pawns — unbounded growth for the remaining ability life.
+		// bTimedOut must still latch server-side so the payload-driven OnTaskCompleted picks
+		// the TimedOut broadcast on both machines.
+		if (IsClientOrRemoteListenServerPawn())
+		{
+			ClientProgressTask();
+		}
 		bTimedOut = true;
 	}
 }
@@ -115,6 +123,16 @@ void UGMCAbilityTask_WaitForInputKeyRelease::OnTaskCompleted()
 
 	EndTask();
 	Duration = AbilitySystemComponent->ActionTimer - StartTime;
+	// Deterministic timeout decision: the ancillary-tick latch races the payload dispatch
+	// across machines (the server's latch runs AFTER the payload dispatch point, so when the
+	// threshold-crossing move and the payload-carrying move batch into the same server frame,
+	// the server would read a stale bTimedOut=false while the client latched true). Re-derive
+	// from the payload-move ActionTimer, which both machines share, so Completed vs TimedOut
+	// never diverges.
+	if (!bTimedOut && MaxDuration > 0 && Duration >= MaxDuration)
+	{
+		bTimedOut = true;
+	}
 	if (!bTimedOut)
 	{
 		Completed.Broadcast(Duration);
@@ -127,9 +145,8 @@ void UGMCAbilityTask_WaitForInputKeyRelease::OnTaskCompleted()
 
 void UGMCAbilityTask_WaitForInputKeyRelease::OnDestroy(bool bInOwnerFinished)
 {
-	Super::OnDestroy(bInOwnerFinished);
-
-	// If the handle is still valid somehow, unbind it.
+	// If the handle is still valid somehow, unbind it. Done BEFORE Super per the engine
+	// contract ("call Super::OnDestroy(bOwnerFinished) as the last thing").
 	if (InputBindingHandle != -1)
 	{
 		if (UInputComponent* const InputComponent = GetValid(GetEnhancedInputComponent()))
@@ -139,6 +156,8 @@ void UGMCAbilityTask_WaitForInputKeyRelease::OnDestroy(bool bInOwnerFinished)
 
 		InputBindingHandle = -1;
 	}
+
+	Super::OnDestroy(bInOwnerFinished);
 }
 
 void UGMCAbilityTask_WaitForInputKeyRelease::ProgressTask(FInstancedStruct& TaskData)

--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -1726,21 +1726,34 @@ void UGMC_AbilitySystemComponent::SendTaskDataToActiveAbility(bool bFromMovement
 	const FGMCAbilityTaskData TaskDataFromInstance = TaskData.IsValid() ? TaskData.Get<FGMCAbilityTaskData>() : FGMCAbilityTaskData{};
 	if (TaskDataFromInstance != FGMCAbilityTaskData{} && /*safety check*/ TaskDataFromInstance.TaskID >= 0)
 	{
-		if (ActiveAbilities.Contains(TaskDataFromInstance.AbilityID) && ActiveAbilities[TaskDataFromInstance.AbilityID]->bActivateOnMovementTick == bFromMovement)
+		// FindRef-hoist: a GC-nulled map VALUE would pass Contains() and crash the deref chain;
+		// resolve once, null-safe, and reuse below.
+		UGMCAbility* TargetAbility = ActiveAbilities.FindRef(TaskDataFromInstance.AbilityID);
+		if (TargetAbility && TargetAbility->bActivateOnMovementTick == bFromMovement)
 		{
 			// [TaskDiag] probe: TaskData is GMC-bound as ClientAuth_Input, so a client replay
 			// restores the historical payload of every replayed move and re-enters this
-			// dispatch — ProgressTask has no replay guard and tasks have no completion guard,
-			// so a replay crossing a Progress-carrying move RE-RUNS the BP continuation
-			// (double Completed broadcast). Log every replayed dispatch to catch it in the act.
+			// dispatch. With finished tasks unregistering themselves, a replayed payload for an
+			// already-unregistered task is the NORMAL replay outcome (ignored downstream) —
+			// only a replayed dispatch that will reach a LIVE task risks re-running its BP
+			// continuation (double Completed broadcast). Keep that case loud, quiet the rest.
 			if (IsReplayingForGMASLogic())
 			{
-				UE_LOG(LogGMCAbilitySystem, Warning,
-					TEXT("[TaskDiag] Progress payload RE-dispatched during replay (AbilityID=%d TaskID=%d fromMovement=%d). %s"),
-					TaskDataFromInstance.AbilityID, TaskDataFromInstance.TaskID, bFromMovement ? 1 : 0,
-					*ActiveAbilities[TaskDataFromInstance.AbilityID]->GetAbilityCutDiagnostics());
+				if (TargetAbility->RunningTasks.FindRef(TaskDataFromInstance.TaskID) != nullptr)
+				{
+					UE_LOG(LogGMCAbilitySystem, Warning,
+						TEXT("[TaskDiag] Progress payload RE-dispatched during replay (AbilityID=%d TaskID=%d fromMovement=%d). %s"),
+						TaskDataFromInstance.AbilityID, TaskDataFromInstance.TaskID, bFromMovement ? 1 : 0,
+						*TargetAbility->GetAbilityCutDiagnostics());
+				}
+				else
+				{
+					UE_LOG(LogGMCAbilitySystem, Verbose,
+						TEXT("[TaskDiag] Replayed Progress payload for already-unregistered TaskID=%d (AbilityID=%d) — benign, ignored downstream."),
+						TaskDataFromInstance.TaskID, TaskDataFromInstance.AbilityID);
+				}
 			}
-			ActiveAbilities[TaskDataFromInstance.AbilityID]->HandleTaskData(TaskDataFromInstance.TaskID, TaskData);
+			TargetAbility->HandleTaskData(TaskDataFromInstance.TaskID, TaskData);
 		}
 		else if (!ActiveAbilities.Contains(TaskDataFromInstance.AbilityID))
 		{

--- a/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
+++ b/Source/GMCAbilitySystem/Public/Ability/GMCAbility.h
@@ -294,6 +294,17 @@ private:
 
 	bool bEndPending = false;
 
+	// [TaskDiag] census state (server-side diagnostics only, wall-clock): when this ability was
+	// first observed Active with no live task (0 = has live tasks / not yet observed), and a
+	// once-only latch for the stalled-ability log line. See UGMCAbility::AncillaryTick.
+	double TasklessSinceTime = 0.0;
+	bool bTasklessCensusLogged = false;
+
+	// [TaskDiag] once-per-TaskID latch for the heartbeat divergence Warning — a long-lived
+	// divergent task beats at 1/s for the rest of the ability's life; only the first beat
+	// per ID warrants a Warning + full dump.
+	TSet<int> WarnedDivergentTaskIDs;
+
 	float ClientStartTime = 0.f;
 	
 

--- a/Source/GMCAbilitySystem/Public/Ability/Tasks/GMCAbilityTaskBase.h
+++ b/Source/GMCAbilitySystem/Public/Ability/Tasks/GMCAbilityTaskBase.h
@@ -79,6 +79,12 @@ public:
 protected:
 	bool bTaskCompleted;
 
+	// Every end path (EndTask, EndTaskGMAS, watchdog kill, TaskOwnerEnded, ExternalCancel)
+	// funnels through OnDestroy exactly once — the single safe place to unregister from the
+	// owning ability's RunningTasks so a finished task never lingers there as a ghost that
+	// still ticks, heartbeats or watchdogs.
+	virtual void OnDestroy(bool bInOwnerFinished) override;
+
 	/** Task Owner that created us */
 	TWeakObjectPtr<AActor> TaskOwner;
 


### PR DESCRIPTION
## Summary

Structural fixes for the held-ability self-cut (heal cut) diagnosed with the [AbilityCut]/[TaskDiag] probes from #12.

### Root cause
A Finished-but-still-registered server task kept its heartbeat watchdog armed while the destroyed client twin no longer heartbeated — the watchdog then killed a healthy ability on a pure GC-timing race.

### Task lifecycle (`77a5e23`)
- `UGMCAbilityTaskBase::OnDestroy` override unregisters the task from the owning ability's `RunningTasks` — every end path (EndTask, EndTaskGMAS, watchdog kill, TaskOwnerEnded, ExternalCancel) funnels through it exactly once. Value-checked so a never-activated `TaskID=0` task cannot evict the live first task.
- Finished tasks neither heartbeat nor arm the watchdog in `AncillaryTick`.
- `TickTasks` / `AncillaryTickTasks` / `FinishEndAbility` iterate a snapshot (tasks now unregister mid-loop; Completed broadcasts can register new tasks).
- Tick passes bail out when a task ended the whole ability mid-pass.
- [TaskDiag] probes reclassified for the new lifecycle: already-unregistered TaskID = benign end race (Verbose); TaskID above the monotonic counter = real divergence (Warning, once per ID); task-less census replaces the lost ghost-task liveness coverage.
- `SendTaskDataToActiveAbility`: FindRef-hoist so a GC-nulled map value cannot pass `Contains()` and crash.

### WaitForInputKey* tasks (`4027e16`)
- Deterministic timeout: `OnTaskCompleted` re-derives `bTimedOut` from the shared payload-move `ActionTimer`, so Completed vs TimedOut never diverges between machines.
- Dedicated server no longer re-queues `ClientProgressTask` every ancillary tick into a never-drained `QueuedTaskData` (unbounded growth).
- Input unbinding moved before `Super::OnDestroy` per the engine contract.

## Test plan
- [ ] PIE 2-player: hold heal to completion and through interrupts — no watchdog cut
- [ ] Dedicated server: WaitForInputKey ability held past MaxDuration — TimedOut on both sides, no queue growth

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task lifecycle management to prevent state divergence between client and server instances.
  * Enhanced timeout handling in input tasks to prevent repeated data queueing on dedicated servers.
  * Fixed potential iteration issues when tasks end during processing.
  * Refined task completion logic to ensure consistent state broadcasts across networked instances.

* **Improvements**
  * Added diagnostic logging to identify and track task management issues and timing gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->