### PR TITLE
feat: bPauseEffectAffectsDuration Implementation

### DIFF
--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -1624,6 +1624,14 @@ void UGMC_AbilitySystemComponent::BuildActiveEffectsSnapshot(TArray<FGMCEffectSn
 		{
 			continue;
 		}
+		
+		// If the effect's timing is currently paused, the pending
+		// StartTime shift hasn't been applied yet, so measure elapsed up to the
+		// pause anchor instead of the live ActionTimer — otherwise the joiner
+		// would see the paused span as consumed duration.
+		const double ElapsedRefTime = Effect->PausedAtActionTimer >= 0.0
+			? Effect->PausedAtActionTimer
+			: ActionTimer;
 
 		FGMCEffectSnapshot Snapshot;
 		Snapshot.EffectClass = Effect->GetClass();
@@ -1632,7 +1640,7 @@ void UGMC_AbilitySystemComponent::BuildActiveEffectsSnapshot(TArray<FGMCEffectSn
 		// the client can rebuild StartTime in its own local clock — preserves
 		// periodic-tick boundary alignment and remaining duration without
 		// exposing the server's absolute clock.
-		Snapshot.TimeSinceStart = ActionTimer - Effect->EffectData.StartTime;
+		Snapshot.TimeSinceStart = ElapsedRefTime - Effect->EffectData.StartTime;
 		Snapshot.Duration = Effect->EffectData.Duration;
 		Snapshot.bServerAuth = Effect->EffectData.bServerAuth;
 		Snapshot.EffectTag = Effect->EffectData.EffectTag;

--- a/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
+++ b/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
@@ -7,6 +7,7 @@
 #include "Components/GMCAbilityComponent.h"
 #include "Interfaces/IPluginManager.h"
 #include "Kismet/KismetSystemLibrary.h"
+#include "Settings/GMASNetworkTimingSettings.h"
 
 #if WITH_EDITOR
 void UGMCAbilityEffect::PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent)
@@ -255,7 +256,45 @@ void UGMCAbilityEffect::Tick(float DeltaTime)
 		return;
 	}
 
-	EffectData.CurrentDuration = OwnerAbilityComponent->ActionTimer - EffectData.StartTime;
+	// Timing pause: On the first paused tick, latch the current move window's start
+	// (ActionTimer - DeltaTime); on the first unpaused tick, shift StartTime/EndTime
+	// forward by the paused span and clear the latch. The window start is invariant
+	// across combined-client-move re-executions and identical on server and client,
+	// so both sides compute the same shift. Skipped during replay: rewound bound tag
+	// state would latch/shift off transient values and corrupt the live anchor.
+	if (EffectData.PauseEffect.IsEmpty() == false
+		&& OwnerAbilityComponent && OwnerAbilityComponent->IsReplayingForGMASLogic() == false)
+	{
+		const double WindowStart = OwnerAbilityComponent->ActionTimer - DeltaTime;
+		if (IsPaused())
+		{
+			if (PausedAtActionTimer < 0.0)
+			{
+				PausedAtActionTimer = WindowStart;
+			}
+		}
+		else if (PausedAtActionTimer >= 0.0)
+		{
+			const double PausedSpan = FMath::Max(0.0, WindowStart - PausedAtActionTimer);
+			EffectData.StartTime += PausedSpan;
+			EffectData.EndTime += PausedSpan;
+			PausedAtActionTimer = -1.0;
+		}
+	}
+
+	// While the latch is armed, CurrentDuration holds at the anchor and CheckState
+	// is skipped below (no Initialized->Started transition, no duration expiry). On
+	// unpause the shift above preserves continuity: ActionTimer - shifted StartTime
+	// resumes exactly from the held value.
+	const bool bTimingPaused = PausedAtActionTimer >= 0.0;
+	if (bTimingPaused)
+	{
+		EffectData.CurrentDuration = PausedAtActionTimer - EffectData.StartTime;
+	} else
+	{
+		EffectData.CurrentDuration = OwnerAbilityComponent->ActionTimer - EffectData.StartTime;
+	}
+	
 	TickEvent(DeltaTime);
 	
 	// Ensure tag requirements are met before applying the effect
@@ -272,7 +311,18 @@ void UGMCAbilityEffect::Tick(float DeltaTime)
 	}
 
 	
-	if (!IsPaused() && CurrentState == EGMASEffectState::Started && AttributeDynamicCondition())
+	// Natural-expiry grace window: alive past EndTime purely so a late-replicating
+	// server pause can still catch this effect (see NaturalExpiryGrace). The window
+	// is gameplay-silent for attribute math — suppressing the modifier block below
+	// keeps a Ticking/Periodic effect's applied work at exactly Duration's worth —
+	// while GrantedTags/abilities linger until the actual end. Symmetric on both
+	// sides (same absolute comparison), so no drain-rate divergence. Grace is 0 for
+	// effects without pause tags and in standalone, so their final-tick application
+	// is untouched.
+	const bool bInExpiryGraceWindow = NaturalExpiryGrace() > 0.0
+		&& OwnerAbilityComponent->ActionTimer >= EffectData.EndTime;
+
+	if (!IsPaused() && bInExpiryGraceWindow == false && CurrentState == EGMASEffectState::Started && AttributeDynamicCondition())
 	{
 		if (EffectData.EffectType == EGMASEffectType::Ticking) {
 		// If there's a period, check to see if it's time to tick
@@ -318,8 +368,11 @@ void UGMCAbilityEffect::Tick(float DeltaTime)
 			// client replay re-executes the same moves with the same stored DeltaTimes, so it
 			// recomputes the SAME boundary crossings (bound attributes were rolled back, so
 			// re-applying is the prediction model working as intended). Do NOT introduce
-			// per-effect accumulators here (e.g. pause-time shifting): they would mutate
-			// during replayed ticks without being rolled back and desync client from server.
+			// per-tick accumulators here: they would mutate during replayed ticks without
+			// being rolled back and desync client from server. Pause handling respects this:
+			// the timing pause above never accumulates — it latches an absolute anchor and
+			// shifts StartTime once on unpause (replay-gated), so the boundary schedule
+			// moves with StartTime and this computation stays pure.
 			const float CurrentElapsedTime = OwnerAbilityComponent->ActionTimer -  EffectData.StartTime;
 			float PreviousElapsedTime = CurrentElapsedTime - DeltaTime;
 			PreviousElapsedTime = FMath::Max(PreviousElapsedTime, 0.f); // Ensure we don't go negative
@@ -350,14 +403,18 @@ void UGMCAbilityEffect::Tick(float DeltaTime)
 	}
 	else if (CurrentState == EGMASEffectState::Started
 		&& EffectData.EffectType == EGMASEffectType::Periodic
-		&& (IsPaused() || !AttributeDynamicCondition()))
+		&& IsPaused() == false
+		&& bInExpiryGraceWindow == false
+		&& AttributeDynamicCondition() == false)
 	{
-		// Period boundaries crossed while paused (or while the dynamic condition is false)
-		// are DROPPED, not deferred — the schedule stays anchored on StartTime, so the next
-		// application happens at the next absolute boundary after resume. This is a design
-		// constraint, not an oversight: deferring would need a paused-time accumulator,
-		// which cannot be made replay-safe (see the stateless-detection comment above).
-		// Log the drops so balance-affecting pauses are visible instead of silent.
+		// Period boundaries crossed while the dynamic condition is false are DROPPED,
+		// not deferred — the schedule stays anchored on StartTime, so the next
+		// application happens at the next absolute boundary once the condition holds
+		// again. Log the drops so balance-affecting gaps are visible instead of silent.
+		// Pause is excluded here: paused boundaries are NOT dropped — the timing pause
+		// shifts StartTime on unpause, deferring the whole schedule (logging them as
+		// drops would be false noise). Grace-window suppression is likewise by design
+		// (the effect already did Duration's worth of work).
 		const float CurrentElapsedTime = OwnerAbilityComponent->ActionTimer - EffectData.StartTime;
 		const float PreviousElapsedTime = FMath::Max(CurrentElapsedTime - DeltaTime, 0.f);
 		const int32 SkippedTicks = FMath::TruncToInt(CurrentElapsedTime / EffectData.PeriodicInterval)
@@ -365,15 +422,18 @@ void UGMCAbilityEffect::Tick(float DeltaTime)
 		if (SkippedTicks > 0)
 		{
 			UE_LOG(LogGMCAbilitySystem, Verbose,
-				TEXT("Periodic effect %s dropped %d tick(s) while %s (by design — boundaries are not deferred)."),
-				*GetName(), SkippedTicks, IsPaused() ? TEXT("paused") : TEXT("dynamic condition false"));
+				TEXT("Periodic effect %s dropped %d tick(s) while dynamic condition false (by design — boundaries are not deferred)."),
+				*GetName(), SkippedTicks);
 		}
 	}
 
-	
-	
-	
-	CheckState();
+
+
+
+	if (bTimingPaused == false)
+	{
+		CheckState();
+	}
 }
 
 int32 UGMCAbilityEffect::CalculatePeriodicTicksBetween(float Period, float StartActionTimer, float EndActionTimer)
@@ -421,6 +481,21 @@ void UGMCAbilityEffect::UpdateState(EGMASEffectState State, bool Force)
 bool UGMCAbilityEffect::IsPaused()
 {
 	return DoesOwnerHaveTagFromContainer(EffectData.PauseEffect);
+}
+
+double UGMCAbilityEffect::NaturalExpiryGrace() const
+{
+	// Grace only matters for effects whose natural expiry can race a late-replicating
+	// pause — i.e. effects that declare PauseEffect tags AND have a finite Duration.
+	// Infinite effects (Duration == 0) never naturally expire, so there is nothing to
+	// extend. Everything else keeps the exact-EndTime expiry it has always had.
+	// Applied in every net mode so timing is identical between standalone and
+	// networked play.
+	if (EffectData.PauseEffect.IsEmpty()) { return 0.0; }
+	if (EffectData.Duration == 0) { return 0.0; }
+	return EffectData.ClientGraceTime > 0.f
+		? static_cast<double>(EffectData.ClientGraceTime)
+		: static_cast<double>(GetDefault<UGMASNetworkTimingSettings>()->DefaultClientGraceTime);
 }
 
 bool UGMCAbilityEffect::IsEffectModifiersRegisterInHistory() const
@@ -575,7 +650,7 @@ void UGMCAbilityEffect::CheckState()
 			}
 			break;
 		case EGMASEffectState::Started:
-			if (EffectData.Duration != 0 && OwnerAbilityComponent->ActionTimer >= EffectData.EndTime)
+			if (EffectData.Duration != 0 && OwnerAbilityComponent->ActionTimer >= EffectData.EndTime + NaturalExpiryGrace())
 			{
 				EndEffect();
 			}

--- a/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
+++ b/Source/GMCAbilitySystem/Private/Effects/GMCAbilityEffect.cpp
@@ -7,7 +7,6 @@
 #include "Components/GMCAbilityComponent.h"
 #include "Interfaces/IPluginManager.h"
 #include "Kismet/KismetSystemLibrary.h"
-#include "Settings/GMASNetworkTimingSettings.h"
 
 #if WITH_EDITOR
 void UGMCAbilityEffect::PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent)
@@ -262,7 +261,8 @@ void UGMCAbilityEffect::Tick(float DeltaTime)
 	// across combined-client-move re-executions and identical on server and client,
 	// so both sides compute the same shift. Skipped during replay: rewound bound tag
 	// state would latch/shift off transient values and corrupt the live anchor.
-	if (EffectData.PauseEffect.IsEmpty() == false
+	if (EffectData.bPauseEffectAffectsDuration
+		&& EffectData.PauseEffect.IsEmpty() == false
 		&& OwnerAbilityComponent && OwnerAbilityComponent->IsReplayingForGMASLogic() == false)
 	{
 		const double WindowStart = OwnerAbilityComponent->ActionTimer - DeltaTime;
@@ -311,18 +311,7 @@ void UGMCAbilityEffect::Tick(float DeltaTime)
 	}
 
 	
-	// Natural-expiry grace window: alive past EndTime purely so a late-replicating
-	// server pause can still catch this effect (see NaturalExpiryGrace). The window
-	// is gameplay-silent for attribute math — suppressing the modifier block below
-	// keeps a Ticking/Periodic effect's applied work at exactly Duration's worth —
-	// while GrantedTags/abilities linger until the actual end. Symmetric on both
-	// sides (same absolute comparison), so no drain-rate divergence. Grace is 0 for
-	// effects without pause tags and in standalone, so their final-tick application
-	// is untouched.
-	const bool bInExpiryGraceWindow = NaturalExpiryGrace() > 0.0
-		&& OwnerAbilityComponent->ActionTimer >= EffectData.EndTime;
-
-	if (!IsPaused() && bInExpiryGraceWindow == false && CurrentState == EGMASEffectState::Started && AttributeDynamicCondition())
+	if (!IsPaused() && CurrentState == EGMASEffectState::Started && AttributeDynamicCondition())
 	{
 		if (EffectData.EffectType == EGMASEffectType::Ticking) {
 		// If there's a period, check to see if it's time to tick
@@ -403,18 +392,16 @@ void UGMCAbilityEffect::Tick(float DeltaTime)
 	}
 	else if (CurrentState == EGMASEffectState::Started
 		&& EffectData.EffectType == EGMASEffectType::Periodic
-		&& IsPaused() == false
-		&& bInExpiryGraceWindow == false
-		&& AttributeDynamicCondition() == false)
+		&& ((IsPaused() && EffectData.bPauseEffectAffectsDuration == false) || AttributeDynamicCondition() == false))
 	{
-		// Period boundaries crossed while the dynamic condition is false are DROPPED,
-		// not deferred — the schedule stays anchored on StartTime, so the next
-		// application happens at the next absolute boundary once the condition holds
-		// again. Log the drops so balance-affecting gaps are visible instead of silent.
-		// Pause is excluded here: paused boundaries are NOT dropped — the timing pause
-		// shifts StartTime on unpause, deferring the whole schedule (logging them as
-		// drops would be false noise). Grace-window suppression is likewise by design
-		// (the effect already did Duration's worth of work).
+		// Period boundaries crossed while the dynamic condition is false — or while
+		// paused without bPauseEffectAffectsDuration — are DROPPED, not deferred: the
+		// schedule stays anchored on StartTime, so the next application happens at the
+		// next absolute boundary once the gate clears. Log the drops so
+		// balance-affecting gaps are visible instead of silent. A pause WITH
+		// bPauseEffectAffectsDuration is excluded: its boundaries are NOT dropped — the
+		// timing pause shifts StartTime on unpause, deferring the whole schedule
+		// (logging them as drops would be false noise).
 		const float CurrentElapsedTime = OwnerAbilityComponent->ActionTimer - EffectData.StartTime;
 		const float PreviousElapsedTime = FMath::Max(CurrentElapsedTime - DeltaTime, 0.f);
 		const int32 SkippedTicks = FMath::TruncToInt(CurrentElapsedTime / EffectData.PeriodicInterval)
@@ -422,8 +409,8 @@ void UGMCAbilityEffect::Tick(float DeltaTime)
 		if (SkippedTicks > 0)
 		{
 			UE_LOG(LogGMCAbilitySystem, Verbose,
-				TEXT("Periodic effect %s dropped %d tick(s) while dynamic condition false (by design — boundaries are not deferred)."),
-				*GetName(), SkippedTicks);
+				TEXT("Periodic effect %s dropped %d tick(s) while %s (by design — boundaries are not deferred)."),
+				*GetName(), SkippedTicks, IsPaused() ? TEXT("paused") : TEXT("dynamic condition false"));
 		}
 	}
 
@@ -481,21 +468,6 @@ void UGMCAbilityEffect::UpdateState(EGMASEffectState State, bool Force)
 bool UGMCAbilityEffect::IsPaused()
 {
 	return DoesOwnerHaveTagFromContainer(EffectData.PauseEffect);
-}
-
-double UGMCAbilityEffect::NaturalExpiryGrace() const
-{
-	// Grace only matters for effects whose natural expiry can race a late-replicating
-	// pause — i.e. effects that declare PauseEffect tags AND have a finite Duration.
-	// Infinite effects (Duration == 0) never naturally expire, so there is nothing to
-	// extend. Everything else keeps the exact-EndTime expiry it has always had.
-	// Applied in every net mode so timing is identical between standalone and
-	// networked play.
-	if (EffectData.PauseEffect.IsEmpty()) { return 0.0; }
-	if (EffectData.Duration == 0) { return 0.0; }
-	return EffectData.ClientGraceTime > 0.f
-		? static_cast<double>(EffectData.ClientGraceTime)
-		: static_cast<double>(GetDefault<UGMASNetworkTimingSettings>()->DefaultClientGraceTime);
 }
 
 bool UGMCAbilityEffect::IsEffectModifiersRegisterInHistory() const
@@ -650,7 +622,7 @@ void UGMCAbilityEffect::CheckState()
 			}
 			break;
 		case EGMASEffectState::Started:
-			if (EffectData.Duration != 0 && OwnerAbilityComponent->ActionTimer >= EffectData.EndTime + NaturalExpiryGrace())
+			if (EffectData.Duration != 0 && OwnerAbilityComponent->ActionTimer >= EffectData.EndTime)
 			{
 				EndEffect();
 			}

--- a/Source/GMCAbilitySystem/Private/Tests/GMAS_BugFixSpec.cpp
+++ b/Source/GMCAbilitySystem/Private/Tests/GMAS_BugFixSpec.cpp
@@ -1897,6 +1897,7 @@ void FGMASBugFixSpec::Define()
 	});
 
 	// ── PauseEffect timing pause ──────────────────────────────────────────
+	// Opt-in via bPauseEffectAffectsDuration.
 	// While paused, time pauses: Delay, Duration, CurrentDuration and periodic
 	// boundaries stop advancing and resume where they left off. Implemented with
 	// absolute ActionTimer anchors (latch on pause, single StartTime/EndTime
@@ -1909,12 +1910,11 @@ void FGMASBugFixSpec::Define()
 			Effect->AddToRoot();
 
 			// Apply at t=1.0: StartTime=1.0, EndTime=3.0. No modifiers — this test
-			// is about timing only. Grace pinned explicitly so the expiry assertions
-			// below don't depend on the project-settings default.
+			// is about timing only.
 			FGMCAbilityEffectData Data;
 			Data.EffectType          = EGMASEffectType::Persistent;
 			Data.Duration            = 2.f;
-			Data.ClientGraceTime     = 0.5f;
+			Data.bPauseEffectAffectsDuration = true;
 			Data.PauseEffect.AddTag(BurningTag);
 			AbilityComp->ApplyAbilityEffect(Effect, Data);
 
@@ -1942,11 +1942,9 @@ void FGMASBugFixSpec::Define()
 			TestFalse("Still alive with 0.5s remaining", Effect->bCompleted);
 			TestEqual("Resumed: CurrentDuration advances again", Effect->EffectData.CurrentDuration, 1.5);
 
-			// Shifted EndTime 4.5 + 0.5 grace -> actual expiry threshold 5.0.
+			// Expires exactly at the shifted EndTime.
 			AbilityComp->ActionTimer = 4.5;  Effect->Tick(0.5f);
-			TestFalse("Still alive inside the grace window", Effect->bCompleted);
-			AbilityComp->ActionTimer = 5.0;  Effect->Tick(0.5f);
-			TestTrue("Effect ends at shifted EndTime + grace", Effect->bCompleted);
+			TestTrue("Effect ends at shifted EndTime", Effect->bCompleted);
 
 			Effect->RemoveFromRoot();
 		});
@@ -1958,11 +1956,11 @@ void FGMASBugFixSpec::Define()
 			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
 			Effect->AddToRoot();
 
-			// Apply at t=1.0: StartTime=1.0, EndTime=3.0, grace pinned to 0.5.
+			// Apply at t=1.0: StartTime=1.0, EndTime=3.0.
 			FGMCAbilityEffectData Data;
 			Data.EffectType          = EGMASEffectType::Persistent;
 			Data.Duration            = 2.f;
-			Data.ClientGraceTime     = 0.5f;
+			Data.bPauseEffectAffectsDuration = true;
 			Data.PauseEffect.AddTag(BurningTag);
 			AbilityComp->ApplyAbilityEffect(Effect, Data);
 
@@ -1989,11 +1987,11 @@ void FGMASBugFixSpec::Define()
 			TestEqual("Episode 2: shifts accumulate", Effect->EffectData.EndTime, 4.0);
 			TestEqual("Episode 2: CurrentDuration continuous", Effect->EffectData.CurrentDuration, 1.5);
 
-			// Lifetime = Duration + both paused spans (+ grace): ends at 4.0 + 0.5.
-			AbilityComp->ActionTimer = 4.0;  Effect->Tick(0.5f);
-			TestFalse("Alive until shifted EndTime + grace", Effect->bCompleted);
-			AbilityComp->ActionTimer = 4.5;  Effect->Tick(0.5f);
-			TestTrue("Ends at EndTime + span1 + span2 + grace", Effect->bCompleted);
+			// Lifetime = Duration + both paused spans: ends at the shifted EndTime 4.0.
+			AbilityComp->ActionTimer = 3.75;  Effect->Tick(0.25f);
+			TestFalse("Alive until shifted EndTime", Effect->bCompleted);
+			AbilityComp->ActionTimer = 4.0;  Effect->Tick(0.25f);
+			TestTrue("Ends at EndTime + span1 + span2", Effect->bCompleted);
 
 			Effect->RemoveFromRoot();
 		});
@@ -2008,6 +2006,7 @@ void FGMASBugFixSpec::Define()
 			Data.EffectType          = EGMASEffectType::Persistent;
 			Data.Delay               = 1.f;
 			Data.Duration            = 2.f;
+			Data.bPauseEffectAffectsDuration = true;
 			Data.PauseEffect.AddTag(BurningTag);
 			AbilityComp->ApplyAbilityEffect(Effect, Data);
 			TestEqual("Delayed effect starts Initialized",
@@ -2041,6 +2040,7 @@ void FGMASBugFixSpec::Define()
 			FGMCAbilityEffectData Data;
 			Data.EffectType          = EGMASEffectType::Persistent;
 			Data.Duration            = 2.f;
+			Data.bPauseEffectAffectsDuration = true;
 			Data.PauseEffect.AddTag(BurningTag);
 			AbilityComp->ApplyAbilityEffect(Effect, Data);
 
@@ -2081,7 +2081,7 @@ void FGMASBugFixSpec::Define()
 			FGMCAbilityEffectData Data;
 			Data.EffectType          = EGMASEffectType::Persistent;
 			Data.Duration            = 2.f;
-			Data.ClientGraceTime     = 0.5f;  // pinned so expiry math is settings-independent
+			Data.bPauseEffectAffectsDuration = true;
 			Data.PauseEffect.AddTag(BurningTag);
 			AbilityComp->ApplyAbilityEffect(Effect, Data);
 
@@ -2102,164 +2102,37 @@ void FGMASBugFixSpec::Define()
 			TestEqual("CurrentDuration resumes from the held value", Effect->EffectData.CurrentDuration, 1.5);
 			TestFalse("Effect alive until the shifted EndTime", Effect->bCompleted);
 
-			// Shifted EndTime 3.75 + 0.5 grace -> actual expiry threshold 4.25.
-			AbilityComp->ActionTimer = 4.25;  Effect->Tick(0.5f);
-			TestTrue("Effect ends at shifted EndTime + grace", Effect->bCompleted);
+			// Expires exactly at the shifted EndTime 3.75.
+			AbilityComp->ActionTimer = 3.75;  Effect->Tick(0.5f);
+			TestTrue("Effect ends at shifted EndTime", Effect->bCompleted);
 
 			Effect->RemoveFromRoot();
 		});
 
-	});
-
-	// ── Natural-expiry grace window (PauseEffect) ─────────────────────────
-	// Pause-capable effects (non-empty PauseEffect) end at EndTime + grace instead
-	// of EndTime, with modifiers suppressed during the window. This closes the
-	// latency race where a server-applied pause replicates after the client's copy
-	// already expired: the client's effect is still alive (gameplay-silent) and can
-	// latch. Applied in every net mode so timing matches between standalone and
-	// networked play. Grace is 0 for effects without pause tags — their expiry is
-	// untouched.
-	Describe("Natural-expiry grace window (PauseEffect)", [this]()
-	{
-		It("Effect without pause tags still ends exactly at EndTime", [this]()
+		It("bPauseEffectAffectsDuration=false: pause suppresses ticking but time keeps advancing", [this]()
 		{
+			// Default behavior: pause must not touch timing — no anchor, no
+			// StartTime/EndTime shift, expiry at the original EndTime even while paused.
 			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
 			Effect->AddToRoot();
 
-			FGMCAbilityEffectData Data;
-			Data.EffectType     = EGMASEffectType::Persistent;
-			Data.Duration       = 2.f;
-			Data.ClientGraceTime = 0.5f;  // must be inert without pause tags
-			AbilityComp->ApplyAbilityEffect(Effect, Data);
-
-			AbilityComp->ActionTimer = 3.0;  Effect->Tick(1.f);
-			TestTrue("No pause tags: no grace, expires at EndTime", Effect->bCompleted);
-
-			Effect->RemoveFromRoot();
-		});
-
-		It("Infinite-duration pause-capable effect gets no grace window", [this]()
-		{
-			// Duration == 0 means EndTime == StartTime, so without the Duration guard
-			// in NaturalExpiryGrace the suppression window would swallow every tick
-			// from the moment the effect starts. Infinite effects must tick normally.
-			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
-			Effect->AddToRoot();
-
-			FGMCAbilityEffectData Data;
-			Data.EffectType     = EGMASEffectType::Ticking;
-			Data.Duration       = 0.f;  // infinite
-			Data.ClientGraceTime = 0.5f;
-			Data.PauseEffect.AddTag(BurningTag);
-			Data.Modifiers.Add(MakeHealthMod(-10.f));
-			AbilityComp->ApplyAbilityEffect(Effect, Data);
-
-			TestEqual("Infinite effect reports zero grace", Effect->NaturalExpiryGrace(), 0.0);
-
-			// ActionTimer is past EndTime (== StartTime) from the first tick; the
-			// modifier must still apply.
-			AbilityComp->ActionTimer = 2.0;  Effect->Tick(1.f);
-			AbilityComp->ProcessAttributes(true);
-			TestFalse("Infinite effect never expires", Effect->bCompleted);
-			TestEqual("Modifiers keep applying past EndTime == StartTime",
-				AbilityComp->GetAttributeByTag(HealthTag)->Value, 90.f);
-
-			Effect->RemoveFromRoot();
-		});
-
-		It("Pause-capable effect survives the window and ends at EndTime + grace", [this]()
-		{
-			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
-			Effect->AddToRoot();
-
-			// Apply at t=1.0: EndTime=3.0, grace 0.5 -> actual expiry threshold 3.5.
-			// Pause-capable (tags declared) but never actually paused.
+			// Apply at t=1.0: StartTime=1.0, EndTime=3.0. Flag left at its default (false).
 			FGMCAbilityEffectData Data;
 			Data.EffectType          = EGMASEffectType::Persistent;
 			Data.Duration            = 2.f;
-			Data.ClientGraceTime     = 0.5f;
 			Data.PauseEffect.AddTag(BurningTag);
 			AbilityComp->ApplyAbilityEffect(Effect, Data);
-
-			AbilityComp->ActionTimer = 3.25;  Effect->Tick(1.f);
-			TestFalse("Alive inside the grace window (past EndTime)", Effect->bCompleted);
-
-			AbilityComp->ActionTimer = 3.5;  Effect->Tick(0.25f);
-			TestTrue("Ends at EndTime + grace", Effect->bCompleted);
-
-			Effect->RemoveFromRoot();
-		});
-
-		It("Modifiers are suppressed inside the grace window", [this]()
-		{
-			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
-			Effect->AddToRoot();
-
-			// Ticking -10/s health drain, applied at t=1.0: EndTime=3.0, threshold 3.5.
-			// Pause-capable (tags declared) but never actually paused.
-			FGMCAbilityEffectData Data;
-			Data.EffectType          = EGMASEffectType::Ticking;
-			Data.Duration            = 2.f;
-			Data.ClientGraceTime     = 0.5f;
-			Data.PauseEffect.AddTag(BurningTag);
-			Data.Modifiers.Add(MakeHealthMod(-10.f));
-			AbilityComp->ApplyAbilityEffect(Effect, Data);
-
-			// One second of live ticking applies the drain.
-			AbilityComp->ActionTimer = 2.0;  Effect->Tick(1.f);
-			AbilityComp->ProcessAttributes(true);
-			TestEqual("Live tick drains", AbilityComp->GetAttributeByTag(HealthTag)->Value, 90.f);
-
-			// Tick landing in the window applies nothing — the effect's modifier work
-			// stays at Duration's worth even though the object is still alive.
-			AbilityComp->ActionTimer = 3.0;  Effect->Tick(1.f);
-			AbilityComp->ProcessAttributes(true);
-			TestFalse("Still alive in the window", Effect->bCompleted);
-			TestEqual("Window tick is gameplay-silent", AbilityComp->GetAttributeByTag(HealthTag)->Value, 90.f);
-
-			AbilityComp->ActionTimer = 3.5;  Effect->Tick(0.5f);
-			AbilityComp->ProcessAttributes(true);
-			TestTrue("Ends at EndTime + grace", Effect->bCompleted);
-			TestEqual("No drain on the ending tick either", AbilityComp->GetAttributeByTag(HealthTag)->Value, 90.f);
-
-			Effect->RemoveFromRoot();
-		});
-
-		It("Pause latched inside the window saves the effect (the latency race)", [this]()
-		{
-			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
-			Effect->AddToRoot();
-
-			// Apply at t=1.0: EndTime=3.0, grace 0.5. The pause tag lands at t=3.25 —
-			// past EndTime, inside the window. Without the grace this effect would
-			// already be gone and the pause would have nothing to catch.
-			FGMCAbilityEffectData Data;
-			Data.EffectType          = EGMASEffectType::Persistent;
-			Data.Duration            = 2.f;
-			Data.ClientGraceTime     = 0.5f;
-			Data.PauseEffect.AddTag(BurningTag);
-			AbilityComp->ApplyAbilityEffect(Effect, Data);
-
-			AbilityComp->ActionTimer = 2.0;  Effect->Tick(1.f);
-			TestFalse("Alive before the window", Effect->bCompleted);
 
 			AbilityComp->AddActiveTag(BurningTag);
-			AbilityComp->ActionTimer = 3.25;  Effect->Tick(0.25f);
-			TestEqual("Anchor latched inside the window", Effect->PausedAtActionTimer, 3.0);
+			AbilityComp->ActionTimer = 2.0;  Effect->Tick(1.f);
+			TestEqual("Anchor never latches", Effect->PausedAtActionTimer, -1.0);
+			TestEqual("CurrentDuration keeps advancing while paused", Effect->EffectData.CurrentDuration, 1.0);
+			TestEqual("EndTime untouched", Effect->EffectData.EndTime, 3.0);
 
-			// Timing paused: survives well past EndTime + grace.
-			AbilityComp->ActionTimer = 4.0;  Effect->Tick(0.75f);
-			TestFalse("Paused effect survives past EndTime + grace", Effect->bCompleted);
+			AbilityComp->ActionTimer = 3.0;  Effect->Tick(1.f);
+			TestTrue("Expires at the original EndTime while still paused", Effect->bCompleted);
 
-			// Unpause at t=4.25: shift = (4.0 - 3.0) = 1.0 -> EndTime 4.0, threshold 4.5.
 			AbilityComp->RemoveActiveTag(BurningTag);
-			AbilityComp->ActionTimer = 4.25;  Effect->Tick(0.25f);
-			TestEqual("EndTime shifted by the paused span", Effect->EffectData.EndTime, 4.0);
-			TestFalse("Alive until the shifted threshold", Effect->bCompleted);
-
-			AbilityComp->ActionTimer = 4.5;  Effect->Tick(0.25f);
-			TestTrue("Ends at shifted EndTime + grace", Effect->bCompleted);
-
 			Effect->RemoveFromRoot();
 		});
 	});

--- a/Source/GMCAbilitySystem/Private/Tests/GMAS_BugFixSpec.cpp
+++ b/Source/GMCAbilitySystem/Private/Tests/GMAS_BugFixSpec.cpp
@@ -1895,6 +1895,374 @@ void FGMASBugFixSpec::Define()
 				AbilityComp->GetBoundQueueV2ForTest().ClientQueuedOperations.Num(), 1);
 		});
 	});
+
+	// ── PauseEffect timing pause ──────────────────────────────────────────
+	// While paused, time pauses: Delay, Duration, CurrentDuration and periodic
+	// boundaries stop advancing and resume where they left off. Implemented with
+	// absolute ActionTimer anchors (latch on pause, single StartTime/EndTime
+	// shift on unpause) — see UGMCAbilityEffect::Tick.
+	Describe("PauseEffect timing pause", [this]()
+	{
+		It("Duration and CurrentDuration hold while paused and resume on unpause", [this]()
+		{
+			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
+			Effect->AddToRoot();
+
+			// Apply at t=1.0: StartTime=1.0, EndTime=3.0. No modifiers — this test
+			// is about timing only. Grace pinned explicitly so the expiry assertions
+			// below don't depend on the project-settings default.
+			FGMCAbilityEffectData Data;
+			Data.EffectType          = EGMASEffectType::Persistent;
+			Data.Duration            = 2.f;
+			Data.ClientGraceTime     = 0.5f;
+			Data.PauseEffect.AddTag(BurningTag);
+			AbilityComp->ApplyAbilityEffect(Effect, Data);
+
+			// Unpaused tick to t=2.0: one second of real duration accrues.
+			AbilityComp->ActionTimer = 2.0;
+			Effect->Tick(1.f);
+			TestEqual("Unpaused: CurrentDuration advances", Effect->EffectData.CurrentDuration, 1.0);
+
+			// Pause and tick past the ORIGINAL EndTime (3.0). The pause anchor latches
+			// to the first paused move's window start (2.5 - 0.5 = 2.0).
+			AbilityComp->AddActiveTag(BurningTag);
+			AbilityComp->ActionTimer = 2.5;  Effect->Tick(0.5f);
+			TestEqual("Paused: anchor latched at the window start", Effect->PausedAtActionTimer, 2.0);
+			AbilityComp->ActionTimer = 3.5;  Effect->Tick(1.f);
+			TestFalse("Paused effect survives past its original EndTime", Effect->bCompleted);
+			TestEqual("Paused: CurrentDuration holds", Effect->EffectData.CurrentDuration, 1.0);
+			TestEqual("Paused: EndTime untouched while latched", Effect->EffectData.EndTime, 3.0);
+
+			// Unpause: one shift of (unpause window start - anchor) = 3.5 - 2.0 = 1.5,
+			// leaving exactly the remaining 1s of duration.
+			AbilityComp->RemoveActiveTag(BurningTag);
+			AbilityComp->ActionTimer = 4.0;  Effect->Tick(0.5f);
+			TestEqual("Resumed: EndTime shifted by the paused span", Effect->EffectData.EndTime, 4.5);
+			TestEqual("Resumed: anchor cleared", Effect->PausedAtActionTimer, -1.0);
+			TestFalse("Still alive with 0.5s remaining", Effect->bCompleted);
+			TestEqual("Resumed: CurrentDuration advances again", Effect->EffectData.CurrentDuration, 1.5);
+
+			// Shifted EndTime 4.5 + 0.5 grace -> actual expiry threshold 5.0.
+			AbilityComp->ActionTimer = 4.5;  Effect->Tick(0.5f);
+			TestFalse("Still alive inside the grace window", Effect->bCompleted);
+			AbilityComp->ActionTimer = 5.0;  Effect->Tick(0.5f);
+			TestTrue("Effect ends at shifted EndTime + grace", Effect->bCompleted);
+
+			Effect->RemoveFromRoot();
+		});
+
+		It("Multiple pause episodes re-latch and accumulate their shifts", [this]()
+		{
+			// The anchor is per-episode: unpause clears it (-1.0), so a second pause
+			// latches fresh and its span compounds onto StartTime/EndTime.
+			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
+			Effect->AddToRoot();
+
+			// Apply at t=1.0: StartTime=1.0, EndTime=3.0, grace pinned to 0.5.
+			FGMCAbilityEffectData Data;
+			Data.EffectType          = EGMASEffectType::Persistent;
+			Data.Duration            = 2.f;
+			Data.ClientGraceTime     = 0.5f;
+			Data.PauseEffect.AddTag(BurningTag);
+			AbilityComp->ApplyAbilityEffect(Effect, Data);
+
+			AbilityComp->ActionTimer = 1.5;  Effect->Tick(0.5f);
+			TestEqual("Unpaused: CurrentDuration advances", Effect->EffectData.CurrentDuration, 0.5);
+
+			// Episode 1: paused window [1.5, 2.0].
+			AbilityComp->AddActiveTag(BurningTag);
+			AbilityComp->ActionTimer = 2.0;  Effect->Tick(0.5f);
+			TestEqual("Episode 1: anchor latched", Effect->PausedAtActionTimer, 1.5);
+			AbilityComp->RemoveActiveTag(BurningTag);
+			AbilityComp->ActionTimer = 2.5;  Effect->Tick(0.5f);
+			TestEqual("Episode 1: EndTime shifted by span", Effect->EffectData.EndTime, 3.5);
+			TestEqual("Episode 1: anchor cleared", Effect->PausedAtActionTimer, -1.0);
+			TestEqual("Episode 1: CurrentDuration continuous", Effect->EffectData.CurrentDuration, 1.0);
+
+			// Episode 2: paused window [2.5, 3.0] — anchor re-latches.
+			AbilityComp->AddActiveTag(BurningTag);
+			AbilityComp->ActionTimer = 3.0;  Effect->Tick(0.5f);
+			TestEqual("Episode 2: anchor re-latched fresh", Effect->PausedAtActionTimer, 2.5);
+			TestEqual("Episode 2: CurrentDuration holds again", Effect->EffectData.CurrentDuration, 1.0);
+			AbilityComp->RemoveActiveTag(BurningTag);
+			AbilityComp->ActionTimer = 3.5;  Effect->Tick(0.5f);
+			TestEqual("Episode 2: shifts accumulate", Effect->EffectData.EndTime, 4.0);
+			TestEqual("Episode 2: CurrentDuration continuous", Effect->EffectData.CurrentDuration, 1.5);
+
+			// Lifetime = Duration + both paused spans (+ grace): ends at 4.0 + 0.5.
+			AbilityComp->ActionTimer = 4.0;  Effect->Tick(0.5f);
+			TestFalse("Alive until shifted EndTime + grace", Effect->bCompleted);
+			AbilityComp->ActionTimer = 4.5;  Effect->Tick(0.5f);
+			TestTrue("Ends at EndTime + span1 + span2 + grace", Effect->bCompleted);
+
+			Effect->RemoveFromRoot();
+		});
+
+		It("Delay holds while paused: Initialized->Started stalls until unpause", [this]()
+		{
+			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
+			Effect->AddToRoot();
+
+			// Apply at t=1.0 with Delay=1: StartTime=2.0, EndTime=4.0.
+			FGMCAbilityEffectData Data;
+			Data.EffectType          = EGMASEffectType::Persistent;
+			Data.Delay               = 1.f;
+			Data.Duration            = 2.f;
+			Data.PauseEffect.AddTag(BurningTag);
+			AbilityComp->ApplyAbilityEffect(Effect, Data);
+			TestEqual("Delayed effect starts Initialized",
+				static_cast<int>(Effect->CurrentState), static_cast<int>(EGMASEffectState::Initialized));
+
+			// Pause during the delay window and tick past the original StartTime.
+			// Anchor latches at 2.0 - 1.0 = 1.0; StartTime stays put while latched.
+			AbilityComp->AddActiveTag(BurningTag);
+			AbilityComp->ActionTimer = 2.0;  Effect->Tick(1.f);
+			AbilityComp->ActionTimer = 3.0;  Effect->Tick(1.f);
+			TestEqual("Paused: still Initialized past original StartTime",
+				static_cast<int>(Effect->CurrentState), static_cast<int>(EGMASEffectState::Initialized));
+			TestEqual("Paused: StartTime untouched while latched", Effect->EffectData.StartTime, 2.0);
+
+			// Unpause: shift = (4.0 - 1.0) - 1.0 = 2.0 -> StartTime 4.0; the same tick's
+			// CheckState sees ActionTimer reach it and starts the effect.
+			AbilityComp->RemoveActiveTag(BurningTag);
+			AbilityComp->ActionTimer = 4.0;  Effect->Tick(1.f);
+			TestEqual("Resumed: StartTime shifted by the paused span", Effect->EffectData.StartTime, 4.0);
+			TestEqual("Resumed: delay completes and effect starts",
+				static_cast<int>(Effect->CurrentState), static_cast<int>(EGMASEffectState::Started));
+
+			Effect->RemoveFromRoot();
+		});
+
+		It("Replay ticks do not compound the pause shift", [this]()
+		{
+			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
+			Effect->AddToRoot();
+
+			FGMCAbilityEffectData Data;
+			Data.EffectType          = EGMASEffectType::Persistent;
+			Data.Duration            = 2.f;
+			Data.PauseEffect.AddTag(BurningTag);
+			AbilityComp->ApplyAbilityEffect(Effect, Data);
+
+			AbilityComp->AddActiveTag(BurningTag);
+
+			// Replayed moves re-enter Tick — the anchor must NOT latch off rewound state.
+			AbilityComp->bForceReplayingForTest = true;
+			AbilityComp->ActionTimer = 2.0;  Effect->Tick(1.f);
+			TestEqual("Replay: anchor not latched", Effect->PausedAtActionTimer, -1.0);
+			TestEqual("Replay: StartTime unshifted", Effect->EffectData.StartTime, 1.0);
+			TestEqual("Replay: EndTime unshifted",   Effect->EffectData.EndTime,   3.0);
+
+			// Back to live ticking: the anchor latches at the live window start.
+			AbilityComp->bForceReplayingForTest = false;
+			AbilityComp->ActionTimer = 2.5;  Effect->Tick(0.5f);
+			TestEqual("Live: anchor latches after replay", Effect->PausedAtActionTimer, 2.0);
+
+			// Unpause: shift = (3.0 - 0.5) - 2.0 = 0.5.
+			AbilityComp->RemoveActiveTag(BurningTag);
+			AbilityComp->ActionTimer = 3.0;  Effect->Tick(0.5f);
+			TestEqual("Live: unpause shift applied once", Effect->EffectData.EndTime, 3.5);
+			TestFalse("Effect alive after shifted EndTime moved out of reach", Effect->bCompleted);
+
+			Effect->RemoveFromRoot();
+		});
+
+		It("Combined-move re-execution does not compound the pause shift", [this]()
+		{
+			// GMC clients re-execute a combined move every frame it is extended: same
+			// window, growing DeltaTime, advancing timestamp (CL_ExecuteMove applies the
+			// move's start state and runs ExecuteMove with the accumulated delta). The
+			// server executes that move exactly ONCE with the final delta. Anchor-based
+			// bookkeeping must therefore be a no-op on re-execution; per-tick DeltaTime
+			// accumulation would shift 0.25+0.5+0.75 = 1.5 here instead of 0.75.
+			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
+			Effect->AddToRoot();
+
+			FGMCAbilityEffectData Data;
+			Data.EffectType          = EGMASEffectType::Persistent;
+			Data.Duration            = 2.f;
+			Data.ClientGraceTime     = 0.5f;  // pinned so expiry math is settings-independent
+			Data.PauseEffect.AddTag(BurningTag);
+			AbilityComp->ApplyAbilityEffect(Effect, Data);
+
+			AbilityComp->AddActiveTag(BurningTag);
+
+			// Paused window [2.0, 2.75] executed three times as the move combines:
+			// every re-execution sees the same window start (timestamp - delta = 2.0).
+			AbilityComp->ActionTimer = 2.25;  Effect->Tick(0.25f);
+			AbilityComp->ActionTimer = 2.5;   Effect->Tick(0.5f);
+			AbilityComp->ActionTimer = 2.75;  Effect->Tick(0.75f);
+			TestEqual("Anchor stable across re-executions", Effect->PausedAtActionTimer, 2.0);
+
+			// Unpause on the next move: shift = (3.25 - 0.5) - 2.0 = 0.75 — the real
+			// paused span, applied exactly once.
+			AbilityComp->RemoveActiveTag(BurningTag);
+			AbilityComp->ActionTimer = 3.25;  Effect->Tick(0.5f);
+			TestEqual("Shift equals the real paused span", Effect->EffectData.EndTime, 3.75);
+			TestEqual("CurrentDuration resumes from the held value", Effect->EffectData.CurrentDuration, 1.5);
+			TestFalse("Effect alive until the shifted EndTime", Effect->bCompleted);
+
+			// Shifted EndTime 3.75 + 0.5 grace -> actual expiry threshold 4.25.
+			AbilityComp->ActionTimer = 4.25;  Effect->Tick(0.5f);
+			TestTrue("Effect ends at shifted EndTime + grace", Effect->bCompleted);
+
+			Effect->RemoveFromRoot();
+		});
+
+	});
+
+	// ── Natural-expiry grace window (PauseEffect) ─────────────────────────
+	// Pause-capable effects (non-empty PauseEffect) end at EndTime + grace instead
+	// of EndTime, with modifiers suppressed during the window. This closes the
+	// latency race where a server-applied pause replicates after the client's copy
+	// already expired: the client's effect is still alive (gameplay-silent) and can
+	// latch. Applied in every net mode so timing matches between standalone and
+	// networked play. Grace is 0 for effects without pause tags — their expiry is
+	// untouched.
+	Describe("Natural-expiry grace window (PauseEffect)", [this]()
+	{
+		It("Effect without pause tags still ends exactly at EndTime", [this]()
+		{
+			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
+			Effect->AddToRoot();
+
+			FGMCAbilityEffectData Data;
+			Data.EffectType     = EGMASEffectType::Persistent;
+			Data.Duration       = 2.f;
+			Data.ClientGraceTime = 0.5f;  // must be inert without pause tags
+			AbilityComp->ApplyAbilityEffect(Effect, Data);
+
+			AbilityComp->ActionTimer = 3.0;  Effect->Tick(1.f);
+			TestTrue("No pause tags: no grace, expires at EndTime", Effect->bCompleted);
+
+			Effect->RemoveFromRoot();
+		});
+
+		It("Infinite-duration pause-capable effect gets no grace window", [this]()
+		{
+			// Duration == 0 means EndTime == StartTime, so without the Duration guard
+			// in NaturalExpiryGrace the suppression window would swallow every tick
+			// from the moment the effect starts. Infinite effects must tick normally.
+			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
+			Effect->AddToRoot();
+
+			FGMCAbilityEffectData Data;
+			Data.EffectType     = EGMASEffectType::Ticking;
+			Data.Duration       = 0.f;  // infinite
+			Data.ClientGraceTime = 0.5f;
+			Data.PauseEffect.AddTag(BurningTag);
+			Data.Modifiers.Add(MakeHealthMod(-10.f));
+			AbilityComp->ApplyAbilityEffect(Effect, Data);
+
+			TestEqual("Infinite effect reports zero grace", Effect->NaturalExpiryGrace(), 0.0);
+
+			// ActionTimer is past EndTime (== StartTime) from the first tick; the
+			// modifier must still apply.
+			AbilityComp->ActionTimer = 2.0;  Effect->Tick(1.f);
+			AbilityComp->ProcessAttributes(true);
+			TestFalse("Infinite effect never expires", Effect->bCompleted);
+			TestEqual("Modifiers keep applying past EndTime == StartTime",
+				AbilityComp->GetAttributeByTag(HealthTag)->Value, 90.f);
+
+			Effect->RemoveFromRoot();
+		});
+
+		It("Pause-capable effect survives the window and ends at EndTime + grace", [this]()
+		{
+			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
+			Effect->AddToRoot();
+
+			// Apply at t=1.0: EndTime=3.0, grace 0.5 -> actual expiry threshold 3.5.
+			// Pause-capable (tags declared) but never actually paused.
+			FGMCAbilityEffectData Data;
+			Data.EffectType          = EGMASEffectType::Persistent;
+			Data.Duration            = 2.f;
+			Data.ClientGraceTime     = 0.5f;
+			Data.PauseEffect.AddTag(BurningTag);
+			AbilityComp->ApplyAbilityEffect(Effect, Data);
+
+			AbilityComp->ActionTimer = 3.25;  Effect->Tick(1.f);
+			TestFalse("Alive inside the grace window (past EndTime)", Effect->bCompleted);
+
+			AbilityComp->ActionTimer = 3.5;  Effect->Tick(0.25f);
+			TestTrue("Ends at EndTime + grace", Effect->bCompleted);
+
+			Effect->RemoveFromRoot();
+		});
+
+		It("Modifiers are suppressed inside the grace window", [this]()
+		{
+			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
+			Effect->AddToRoot();
+
+			// Ticking -10/s health drain, applied at t=1.0: EndTime=3.0, threshold 3.5.
+			// Pause-capable (tags declared) but never actually paused.
+			FGMCAbilityEffectData Data;
+			Data.EffectType          = EGMASEffectType::Ticking;
+			Data.Duration            = 2.f;
+			Data.ClientGraceTime     = 0.5f;
+			Data.PauseEffect.AddTag(BurningTag);
+			Data.Modifiers.Add(MakeHealthMod(-10.f));
+			AbilityComp->ApplyAbilityEffect(Effect, Data);
+
+			// One second of live ticking applies the drain.
+			AbilityComp->ActionTimer = 2.0;  Effect->Tick(1.f);
+			AbilityComp->ProcessAttributes(true);
+			TestEqual("Live tick drains", AbilityComp->GetAttributeByTag(HealthTag)->Value, 90.f);
+
+			// Tick landing in the window applies nothing — the effect's modifier work
+			// stays at Duration's worth even though the object is still alive.
+			AbilityComp->ActionTimer = 3.0;  Effect->Tick(1.f);
+			AbilityComp->ProcessAttributes(true);
+			TestFalse("Still alive in the window", Effect->bCompleted);
+			TestEqual("Window tick is gameplay-silent", AbilityComp->GetAttributeByTag(HealthTag)->Value, 90.f);
+
+			AbilityComp->ActionTimer = 3.5;  Effect->Tick(0.5f);
+			AbilityComp->ProcessAttributes(true);
+			TestTrue("Ends at EndTime + grace", Effect->bCompleted);
+			TestEqual("No drain on the ending tick either", AbilityComp->GetAttributeByTag(HealthTag)->Value, 90.f);
+
+			Effect->RemoveFromRoot();
+		});
+
+		It("Pause latched inside the window saves the effect (the latency race)", [this]()
+		{
+			UGMCAbilityEffect* Effect = NewObject<UGMCAbilityEffect>(GetTransientPackage());
+			Effect->AddToRoot();
+
+			// Apply at t=1.0: EndTime=3.0, grace 0.5. The pause tag lands at t=3.25 —
+			// past EndTime, inside the window. Without the grace this effect would
+			// already be gone and the pause would have nothing to catch.
+			FGMCAbilityEffectData Data;
+			Data.EffectType          = EGMASEffectType::Persistent;
+			Data.Duration            = 2.f;
+			Data.ClientGraceTime     = 0.5f;
+			Data.PauseEffect.AddTag(BurningTag);
+			AbilityComp->ApplyAbilityEffect(Effect, Data);
+
+			AbilityComp->ActionTimer = 2.0;  Effect->Tick(1.f);
+			TestFalse("Alive before the window", Effect->bCompleted);
+
+			AbilityComp->AddActiveTag(BurningTag);
+			AbilityComp->ActionTimer = 3.25;  Effect->Tick(0.25f);
+			TestEqual("Anchor latched inside the window", Effect->PausedAtActionTimer, 3.0);
+
+			// Timing paused: survives well past EndTime + grace.
+			AbilityComp->ActionTimer = 4.0;  Effect->Tick(0.75f);
+			TestFalse("Paused effect survives past EndTime + grace", Effect->bCompleted);
+
+			// Unpause at t=4.25: shift = (4.0 - 3.0) = 1.0 -> EndTime 4.0, threshold 4.5.
+			AbilityComp->RemoveActiveTag(BurningTag);
+			AbilityComp->ActionTimer = 4.25;  Effect->Tick(0.25f);
+			TestEqual("EndTime shifted by the paused span", Effect->EffectData.EndTime, 4.0);
+			TestFalse("Alive until the shifted threshold", Effect->bCompleted);
+
+			AbilityComp->ActionTimer = 4.5;  Effect->Tick(0.25f);
+			TestTrue("Ends at shifted EndTime + grace", Effect->bCompleted);
+
+			Effect->RemoveFromRoot();
+		});
+	});
 }
 
 #endif // WITH_AUTOMATION_WORKER

--- a/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
+++ b/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
@@ -117,6 +117,11 @@ struct FGMCAbilityEffectData
 	// effect is removed: both client and server arm EndAtActionTimer = ActionTimer + this value so
 	// each side ends on the same logical move tick.
 	//
+	// Also sizes the natural expiry grace window for effects with PauseEffect tags: those end
+	// at EndTime + Grace instead of EndTime (modifiers suppressed during the window), so a
+	// server-applied pause that replicates within the window can still catch the effect
+	// before the client discards it. See UGMCAbilityEffect::NaturalExpiryGrace().
+	//
 	// Sentinel semantics: 0 means "use the project-wide default" from
 	// `UGMASNetworkTimingSettings::DefaultClientGraceTime` (Project Settings → GMC Ability System →
 	// Network Timing, default 0.5s — sized for typical RTT + jitter + one server tick at 30 Hz).
@@ -172,7 +177,17 @@ struct FGMCAbilityEffectData
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer GrantedAbilities;
 
-	// If tag is present, this effect will not tick. Duration is not affected.
+	// If tag is present, this effect will not tick and its time pauses.
+	// - Start Delay WILL pause
+	// - While Paused, TickEvent() WILL to run, use IsPaused() where needed.
+	// - While Paused, PeriodTick() WILL NOT run.
+	// - Persistent modifiers WILL persist while pause
+	// - Ticking and Periodic effects WILL NOT advance; will resume where they left off
+	//
+	// An Effect with PauseEffect declared will gain a grace window (see ClientGraceTime): 
+	// they survive until EndTime + Grace with modifiers suppressed, so a pause landing
+	// within replication latency of EndTime can still catch the effect on the
+	// client instead of racing its local expiry.
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer PauseEffect;
 
@@ -343,6 +358,13 @@ public:
 
 	virtual bool IsPaused();
 
+	// Natural-expiry grace window (seconds) for this effect: effects with PauseEffect
+	// tags end at EndTime + this value (with modifiers suppressed during the window)
+	// so a late-replicating server pause can still catch them.
+	// 0 for effects without pause tags or without a finite Duration (infinite effects
+	// never naturally expire, so there is nothing to extend) — those are unchanged.
+	double NaturalExpiryGrace() const;
+
 	bool IsEffectModifiersRegisterInHistory() const;
 	
 	float ProcessCustomModifier(const TSubclassOf<UGMCAttributeModifierCustom_Base>& MCClass, const FAttribute* attribute);
@@ -360,6 +382,16 @@ public:
 	// Cleared by the polling block in TickActiveEffects when the successor reaches
 	// Validated (real EndEffect runs) or Timeout (OLD is revived).
 	bool bPendingDeathBySuccessor = false;
+
+	// Absolute ActionTimer anchor for the timing pause (PauseEffect tags).
+	// -1.0 = timing not paused. Latched ONCE to the current move window's start
+	// (ActionTimer - DeltaTime) when a pause is first observed; consumed on unpause by
+	// shifting StartTime/EndTime forward by the paused span. The window start is
+	// invariant across combined-client-move re-executions (which re-run the same window
+	// with a growing DeltaTime) and equal on server and client, so both sides compute
+	// the exact same shift — unlike per-tick DeltaTime accumulation, which over-counts
+	// on the client whenever moves are combined while paused.
+	double PausedAtActionTimer { -1.0 };
 
 	// Time that the client applied this Effect. Used for when a client predicts an effect, if the server has not
 	// confirmed this effect within a time range, the effect will be cancelled.

--- a/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
+++ b/Source/GMCAbilitySystem/Public/Effects/GMCAbilityEffect.h
@@ -117,11 +117,6 @@ struct FGMCAbilityEffectData
 	// effect is removed: both client and server arm EndAtActionTimer = ActionTimer + this value so
 	// each side ends on the same logical move tick.
 	//
-	// Also sizes the natural expiry grace window for effects with PauseEffect tags: those end
-	// at EndTime + Grace instead of EndTime (modifiers suppressed during the window), so a
-	// server-applied pause that replicates within the window can still catch the effect
-	// before the client discards it. See UGMCAbilityEffect::NaturalExpiryGrace().
-	//
 	// Sentinel semantics: 0 means "use the project-wide default" from
 	// `UGMASNetworkTimingSettings::DefaultClientGraceTime` (Project Settings → GMC Ability System →
 	// Network Timing, default 0.5s — sized for typical RTT + jitter + one server tick at 30 Hz).
@@ -177,19 +172,26 @@ struct FGMCAbilityEffectData
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer GrantedAbilities;
 
-	// If tag is present, this effect will not tick and its time pauses.
-	// - Start Delay WILL pause
-	// - While Paused, TickEvent() WILL to run, use IsPaused() where needed.
+	// If tag is present, this effect will not tick.
+	// - While Paused, TickEvent() WILL run, use IsPaused() where needed.
 	// - While Paused, PeriodTick() WILL NOT run.
-	// - Persistent modifiers WILL persist while pause
-	// - Ticking and Periodic effects WILL NOT advance; will resume where they left off
+	// - Persistent modifiers WILL persist while paused.
 	//
-	// An Effect with PauseEffect declared will gain a grace window (see ClientGraceTime): 
-	// they survive until EndTime + Grace with modifiers suppressed, so a pause landing
-	// within replication latency of EndTime can still catch the effect on the
-	// client instead of racing its local expiry.
+	// Whether pausing also pauses the effect's TIME (Delay/Duration/periodic schedule)
+	// is controlled by bPauseEffectAffectsDuration below.
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
 	FGameplayTagContainer PauseEffect;
+
+	// When true, pausing also pauses the effect's time: Start Delay, Duration and
+	// CurrentDuration stop advancing and Ticking Effects stop firing while paused,
+	// resuming where they left off (StartTime/EndTime are shifted forward by the
+	// paused span on unpause — see UGMCAbilityEffect::PausedAtActionTimer).
+	//
+	// When false (default), pause only suppresses ticking: time keeps advancing, the
+	// effect still expires at its original EndTime, and Ticking Effects that would
+	// have fired while paused are skipped.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
+	bool bPauseEffectAffectsDuration = false;
 
 	// On activation, will end ability present in this container
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "GMCAbilitySystem")
@@ -358,13 +360,6 @@ public:
 
 	virtual bool IsPaused();
 
-	// Natural-expiry grace window (seconds) for this effect: effects with PauseEffect
-	// tags end at EndTime + this value (with modifiers suppressed during the window)
-	// so a late-replicating server pause can still catch them.
-	// 0 for effects without pause tags or without a finite Duration (infinite effects
-	// never naturally expire, so there is nothing to extend) — those are unchanged.
-	double NaturalExpiryGrace() const;
-
 	bool IsEffectModifiersRegisterInHistory() const;
 	
 	float ProcessCustomModifier(const TSubclassOf<UGMCAttributeModifierCustom_Base>& MCClass, const FAttribute* attribute);
@@ -383,7 +378,8 @@ public:
 	// Validated (real EndEffect runs) or Timeout (OLD is revived).
 	bool bPendingDeathBySuccessor = false;
 
-	// Absolute ActionTimer anchor for the timing pause (PauseEffect tags).
+	// Absolute ActionTimer anchor for the timing pause (PauseEffect tags with
+	// bPauseEffectAffectsDuration). Stays -1.0 when bPauseEffectAffectsDuration is false.
 	// -1.0 = timing not paused. Latched ONCE to the current move window's start
 	// (ActionTimer - DeltaTime) when a pause is first observed; consumed on unpause by
 	// shifting StartTime/EndTime forward by the paused span. The window start is


### PR DESCRIPTION
## Summary
Effects with PauseEffect tags only stopped applying their modifiers while paused — Delay, Duration, CurrentDuration, and periodic boundaries kept advancing on the ActionTimer clock, so a paused effect would silently burn through its lifetime and expire mid-pause. There was no way to truly suspend an effect (e.g. in a cutscene, or the game is paused) and have it resume with its remaining duration intact. 
  
## Changes
Effect timing pause:                                       
- **Effects with PauseEffect tags and bPauseEffectAffectsDuration** now freeze time while paused: Delay, Duration, CurrentDuration stop advancing. Periodic and Ticking modifiers are no longer silently dropped, and resume where they left off on unpause.                
- Implemented with absolute ActionTimer anchors: PausedAtActionTimer latched to the move window start on pause; A single StartTime/EndTime shift on unpause.
- CheckState is skipped and CurrentDuration holds while the latch is armed; TickEvent still fires; already-applied Persistent modifiers remain.

Misc:                                                                         
- BuildActiveEffectsSnapshot measures a paused effect's elapsed time up to the pause anchor so late-joiners don't see the paused span as consumed duration.
- New GMAS_BugFixSpec coverage: 
  - Duration/delay hold + resume, 
  - Replay and combined-move anchor idempotence
  - Grace-window survival/expiry
  - Modifier suppression
  - Pause-inside-window latency race
  - Multiple pauses within a single effect's duration
  - Infinite-duration exclusion
	

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable pause duration behavior for ability effects.

* **Bug Fixes**
  * Fixed pause timing reconstruction for reconnecting clients.
  * Corrected duration pause behavior across multiple pause/unpause cycles.
  * Fixed delay progression while effects are paused.

* **Tests**
  * Added comprehensive automation test coverage for pause timing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->