### PR TITLE
Fix attribute clamping against stale min/max values

### DIFF
--- a/Source/GMCAbilitySystem/Private/Attributes/GMCAttributes.cpp
+++ b/Source/GMCAbilitySystem/Private/Attributes/GMCAttributes.cpp
@@ -22,6 +22,25 @@ void FAttribute::AddModifier(const FGMCAttributeModifier& PendingModifier) const
 	}
 	else
 	{
+		// Permanent path: Before clamping, ensure any attributes we depend on are calculated
+		auto EnsureAttributeUpdated = [this](const FGameplayTag& AttributeTag)
+		{
+			if (AttributeTag.IsValid() && Clamp.AbilityComponent)
+			{
+				if (const FAttribute* Attr = Clamp.AbilityComponent->GetAttributeByTag(AttributeTag))
+				{
+					if (Attr->IsDirty())
+					{
+						Attr->CalculateValue();
+						Attr->bIsDirty = true; // Preserve dirty flag for ProcessAttributes
+					}
+				}
+			}
+		};
+        
+		EnsureAttributeUpdated(Clamp.MinAttributeTag);
+		EnsureAttributeUpdated(Clamp.MaxAttributeTag);
+		
 		// Permanent path: Set/SetReplace overwrite RawValue absolutely; Add accumulates.
 		// Permanent Sets are NOT replay-safe by construction (same caveat as permanent Adds today).
 		if (bIsSet || bIsSetReplace)


### PR DESCRIPTION
When multiple modifiers are applied in a single tick (e.g. +10 to both Health and MaxHealth), clamping could use an outdated bound. Attribute Value calculation is deferred until after all modifiers are applied (presumably for performance), so when Health clamps, MaxHealth's Value is still 100 while its RawValue is already 110.

Calling CalculateValue immediately after every modifier would fix this but defeats the deferred-calculation optimization. Instead, when applying a modifier, check whether a min/max clamp attribute we depend on has been edited but not yet recalculated (marked dirty), and if so, calculate just that attribute right away so we clamp against the updated value.

The updated attribute is flagged as dirty again after updating so it will be calculated again deferred. This makes the calculation be "extra" on top. This could be skipped by removing the bIsDirty = true but unsure if it has any other sideeffects so we keep it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permanent attribute modifier system to properly update prerequisite attributes before applying clamping constraints, ensuring accurate attribute calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->