### PR TITLE
Fix: Unique tag Effect Re-application Fix.

### DIFF
--- a/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
+++ b/Source/GMCAbilitySystem/Private/Components/GMCAbilityComponent.cpp
@@ -3195,8 +3195,12 @@ UGMCAbilityEffect* UGMC_AbilitySystemComponent::ApplyAbilityEffect(UGMCAbilityEf
 	{
 		for (const TPair<int, UGMCAbilityEffect*>& Existing : ActiveEffects)
 		{
+			// bCompleted entries linger in ActiveEffects until the next TickActiveEffects cleanup pass.
+			// They own nothing — tags and modifiers were already released by EndEffect — so counting one
+			// as the live holder of the tag rejects a same-tick reapply and leaves the tag on nobody.
 			if (!Existing.Value
 				|| Existing.Value == Effect
+				|| Existing.Value->bCompleted
 				|| !Existing.Value->EffectData.EffectTag.IsValid()
 				|| !Existing.Value->EffectData.EffectTag.MatchesTagExact(InitializationData.EffectTag))
 			{


### PR DESCRIPTION
## Issue
- An effect with bUniqueByEffectTag that is removed and re-applied before the next TickActiveEffects cleanup pass (i.e. within the same tick) fails to re-apply.
- EndEffect marks the outgoing instance bCompleted and releases its tags and modifiers, but the entry stays in ActiveEffects until cleanup erases it. The uniqueness scan in ApplyAbilityEffect counts that stale entry as the live holder of the tag and rejects the incoming effect.

## Reproduction Steps
- Apply a bUniqueByEffectTag effect
- On next frame:
- RemoveActiveAbilityEffect followed by ApplyAbilityEffect of the same tag.
- The effect re-application will fail.

## Fix
- New effect applications with bUniqueByEffectTag will not account for effects with bCompleted == true, awaiting cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Effects marked as completed no longer prevent new effects with the same tag from being applied.
  * Same-tag ability effects can now be applied correctly before completed effects are fully cleaned up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->